### PR TITLE
🛡️ Sentinel: Fix broken auth for deleted users

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** The `forgotPassword` controller used `req.get("host")` to construct the password reset link. This allows an attacker to inject a malicious Host header, potentially causing the victim to receive a reset link pointing to an attacker-controlled domain.
 **Learning:** Trusting `Host` header for generating absolute URLs is insecure, especially for sensitive actions like password resets.
 **Prevention:** Always use a trusted server-side configuration variable (like `FRONTEND_URL`) to construct absolute URLs. Implement a fallback only if strictly necessary and understood.
+
+## 2025-02-18 - Zombie User Access via Valid JWT
+**Vulnerability:** `isAuthenticatedUser` middleware retrieved the user from DB but failed to check if the result was `null`. This allowed deleted users with valid tokens to bypass authentication checks and potentially crash the server or access protected routes (where `req.user` wasn't checked).
+**Learning:** Trusting that a valid JWT implies a valid user in the database is a dangerous assumption. Middleware must always validate the existence of the entity it retrieves.
+**Prevention:** Always check for `null` after `User.findById` or similar DB calls in authentication middleware.

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -14,6 +14,10 @@ exports.isAuthenticatedUser = catchAsyncErrors(async (req, res, next) => {
 
     req.user = await User.findById(decodedData.id);
 
+    if (!req.user) {
+        return next(new ErrorHandler("User no longer exists", 401));
+    }
+
     next();
 });
 exports.authorizedRoles = (...roles) => {

--- a/backend/tests/integration/auth_deleted_user.test.js
+++ b/backend/tests/integration/auth_deleted_user.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+const app = require('../../app');
+const User = require('../../models/userModel');
+
+let mongoServer;
+
+jest.setTimeout(30000);
+
+jest.mock('cloudinary', () => ({
+    v2: {
+        config: jest.fn(),
+        uploader: {
+            upload: jest.fn().mockResolvedValue({
+                public_id: 'test_public_id',
+                secure_url: 'https://res.cloudinary.com/demo/image/upload/sample.jpg',
+            }),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+jest.mock('resend', () => {
+    return {
+        Resend: jest.fn().mockImplementation(() => {
+            return {
+                emails: {
+                    send: jest.fn().mockResolvedValue({ id: 'test_id' }),
+                },
+            };
+        }),
+    };
+});
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    await mongoose.connect(uri);
+});
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+});
+
+afterEach(async () => {
+    await User.deleteMany({});
+    jest.clearAllMocks();
+});
+
+describe('Deleted User Authentication', () => {
+    it('should deny access if user is deleted but token is valid', async () => {
+        // 1. Create User
+        const user = await User.create({
+            name: 'Delete Me',
+            email: 'delete@example.com',
+            password: 'password123',
+            avatar: { public_id: 'id', url: 'url' }
+        });
+
+        // 2. Login to get token
+        const loginRes = await request(app)
+            .post('/api/v1/login')
+            .send({ email: 'delete@example.com', password: 'password123' });
+
+        const tokenCookie = loginRes.headers['set-cookie'];
+        expect(loginRes.status).toBe(200);
+
+        // 3. Delete User from DB
+        await User.deleteOne({ _id: user._id });
+
+        // 4. Access protected route
+        const res = await request(app)
+            .get('/api/v1/me')
+            .set('Cookie', tokenCookie);
+
+        // 5. Expect 401
+        // Without the fix, this might return 200 or 500
+        expect(res.status).toBe(401);
+    });
+});


### PR DESCRIPTION
Fixed a critical vulnerability where deleted users with valid JWT tokens could access protected routes because `isAuthenticatedUser` did not check if `User.findById` returned null. 

Added a regression test to verify that deleted users now receive a 401 Unauthorized response.

---
*PR created automatically by Jules for task [13006882756138629431](https://jules.google.com/task/13006882756138629431) started by @parilsanghvi*