### PR TITLE
🛡️ Sentinel: [HIGH] Fix race condition in stock update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,10 @@
 1. Always implement explicit input validation in the controller layer (fail fast), especially when using `validateBeforeSave: false`.
 2. Add schema-level validation (min/max) as defense-in-depth.
 3. When testing controllers wrapped in `catchAsyncErrors`, mock the middleware to return the execution promise to ensure the test waits for completion.
+
+## 2025-02-19 - Inventory Race Condition & Silent Failure
+**Vulnerability:** The `updateStock` function used a `findById` -> `subtract` -> `save` pattern, which is susceptible to race conditions (two requests reading the same stock). A proposed fix using `updateOne` with `$inc` and `$gte` (to prevent negative stock) introduced a silent failure: if stock was insufficient, `updateOne` returned `modifiedCount: 0`, but the code proceeded to mark the order as "Shipped".
+**Learning:** Atomic updates with conditions (like `{ stock: { $gte: quantity } }`) fail "silently" if the condition isn't met (i.e., they don't throw, they just don't modify anything).
+**Prevention:**
+1. Always check `result.modifiedCount` (or `nModified`) after an atomic update operation with conditions.
+2. Explicitly throw an error if `modifiedCount === 0` to ensure the operation (e.g., order status update) fails if the dependency (stock deduction) failed.

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -123,11 +123,15 @@ exports.updateOrder = catchAsyncErrors(async (req, res, next) => {
 });
 
 async function updateStock(id, quantity) {
-    const product = await Product.findById(id);
-    product.stock = product.stock - quantity;
-    await product.save({
-        validateBeforeSave: false
-    })
+    // Security Fix: Use atomic update with check for sufficient stock to prevent race conditions and negative inventory
+    const result = await Product.updateOne(
+        { _id: id, stock: { $gte: quantity } },
+        { $inc: { stock: -quantity } }
+    );
+
+    if (result.modifiedCount === 0) {
+        throw new ErrorHandler(`Insufficient stock for product ${id}`, 400);
+    }
 }
 
 // delete order --admin

--- a/backend/tests/unit/stock_update.test.js
+++ b/backend/tests/unit/stock_update.test.js
@@ -1,0 +1,88 @@
+const { updateOrder } = require('../../controllers/orderController');
+const Order = require('../../models/orderModel');
+const Product = require('../../models/productModel');
+const ErrorHandler = require('../../utlis/errorhandler');
+
+// Mock middleware
+jest.mock('../../middleware/catchAsyncErrors', () => (fn) => fn);
+
+// Mock models
+jest.mock('../../models/orderModel');
+jest.mock('../../models/productModel');
+
+describe('updateOrder Stock Update Security', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        req = {
+            params: { id: 'order123' },
+            body: { status: 'Shipped' },
+            user: { _id: 'adminId' }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        next = jest.fn();
+        jest.clearAllMocks();
+    });
+
+    it('should use atomic updateOne to prevent race conditions and negative stock', async () => {
+        const mockOrder = {
+            orderStatus: 'Processing',
+            orderItems: [
+                { product: 'prod1', quantity: 2 },
+                { product: 'prod2', quantity: 1 }
+            ],
+            save: jest.fn()
+        };
+
+        Order.findById.mockResolvedValue(mockOrder);
+        Product.updateOne.mockResolvedValue({ modifiedCount: 1 });
+
+        await updateOrder(req, res, next);
+
+        expect(Order.findById).toHaveBeenCalledWith('order123');
+        expect(Product.updateOne).toHaveBeenCalledTimes(2);
+
+        expect(Product.updateOne).toHaveBeenCalledWith(
+            { _id: 'prod1', stock: { $gte: 2 } },
+            { $inc: { stock: -2 } }
+        );
+
+        expect(Product.updateOne).toHaveBeenCalledWith(
+            { _id: 'prod2', stock: { $gte: 1 } },
+            { $inc: { stock: -1 } }
+        );
+
+        expect(mockOrder.orderStatus).toBe('Shipped');
+        expect(mockOrder.save).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should throw error and NOT update order status if stock is insufficient', async () => {
+        const mockOrder = {
+            orderStatus: 'Processing',
+            orderItems: [
+                { product: 'prod1', quantity: 10 }
+            ],
+            save: jest.fn()
+        };
+
+        Order.findById.mockResolvedValue(mockOrder);
+        // Simulate failure (modifiedCount: 0)
+        Product.updateOne.mockResolvedValue({ modifiedCount: 0 });
+
+        await expect(updateOrder(req, res, next)).rejects.toThrow('Insufficient stock for product prod1');
+
+        expect(Product.updateOne).toHaveBeenCalledWith(
+            { _id: 'prod1', stock: { $gte: 10 } },
+            { $inc: { stock: -10 } }
+        );
+
+        // Verify order was NOT saved
+        expect(mockOrder.save).not.toHaveBeenCalled();
+        // Verify response was NOT sent
+        expect(res.status).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Race Condition & Data Integrity in Order Stock Update

**Severity:** HIGH

**Vulnerability:**
The `updateStock` function in `orderController.js` used a read-modify-write pattern (`findById` -> update -> `save`). This is vulnerable to:
1.  **Race Conditions:** Concurrent requests could read the same stock level and overwrite each other's changes, leading to selling more inventory than available.
2.  **Negative Stock:** There was no check to ensure stock >= quantity before deduction (other than a bypassable Mongoose validator which wasn't even strictly enforced for negative values in the logic).
3.  **Silent Failure (Logic Bug):** A naive atomic update fix could fail to deduct stock (if condition failed) but still allow the order to proceed.

**Fix:**
- Implemented atomic update using `Product.updateOne` with `{ $inc: { stock: -quantity } }`.
- Added query condition `{ stock: { $gte: quantity } }` to ensure stock is sufficient *atomically*.
- Added a check for `result.modifiedCount === 0` to explicitly throw an error if the stock deduction fails, preventing the order from being marked as "Shipped" if inventory is missing.

**Verification:**
- Added `backend/tests/unit/stock_update.test.js` which mocks Mongoose to verify:
    1.  `updateOne` is called with correct arguments (atomic decrement + condition).
    2.  The function throws an error if `modifiedCount` is 0 (insufficient stock).
- Validated that the fix addresses both the race condition and the silent failure edge case.

---
*PR created automatically by Jules for task [10342243421359958198](https://jules.google.com/task/10342243421359958198) started by @parilsanghvi*