### PR TITLE
Sentinel: Prevent Account Enumeration in Forgot Password

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,11 @@
 1. Always implement explicit input validation in the controller layer (fail fast), especially when using `validateBeforeSave: false`.
 2. Add schema-level validation (min/max) as defense-in-depth.
 3. When testing controllers wrapped in `catchAsyncErrors`, mock the middleware to return the execution promise to ensure the test waits for completion.
+
+## 2025-02-19 - Account Enumeration in Forgot Password
+**Vulnerability:** The `forgotPassword` endpoint returned a specific 404 "user not found" error when an email did not exist. This allowed attackers to enumerate valid email addresses registered in the system.
+**Learning:** Returning specific error messages for authentication/recovery flows leaks information. Also, Mongoose pre-save hooks using `async/await` should not accept/call `next()` to avoid "next is not a function" errors in newer Mongoose versions/environments, which surfaced during testing.
+**Prevention:**
+1. Always use generic success messages for password recovery (e.g., "If the email exists, we sent a link").
+2. Ensure the response time is somewhat consistent (though complete timing attack mitigation requires more effort like dummy hashing).
+3. Use `async function()` without `next` for Mongoose pre-hooks when using await.

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -71,8 +71,14 @@ exports.forgotPassword = catchAsyncErrors(async (req, res, next) => {
     const user = await User.findOne({
         email: req.body.email,
     })
+
+    const GENERIC_MESSAGE = "If that email address is in our database, we will send you an email to reset your password.";
+
     if (!user) {
-        return next(new ErrorHandler("user not found", 404))
+        return res.status(200).json({
+            success: true,
+            message: GENERIC_MESSAGE,
+        })
     }
     // get resetPassword Token
     const resetToken = await user.getResetPasswordToken();
@@ -94,7 +100,7 @@ exports.forgotPassword = catchAsyncErrors(async (req, res, next) => {
         })
         res.status(200).json({
             success: true,
-            message: `email sent to ${user.email} successfully`,
+            message: GENERIC_MESSAGE,
         })
     } catch (error) {
         user.resetPasswordToken = undefined

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -42,9 +42,9 @@ const userSchema = new mongoose.Schema({
     resetPasswordToken: String,
     resetPasswordExpire: Date,
 })
-userSchema.pre("save", async function (next) {
+userSchema.pre("save", async function () {
     if (!this.isModified("password")) {
-        next();
+        return;
     }
     this.password = await bcrypt.hash(this.password, 10);
 })

--- a/backend/tests/security_account_enumeration.test.js
+++ b/backend/tests/security_account_enumeration.test.js
@@ -1,0 +1,87 @@
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+const app = require('../app');
+const User = require('../models/userModel');
+
+let mongoServer;
+
+// Mock Cloudinary
+jest.mock('cloudinary', () => ({
+    v2: {
+        config: jest.fn(),
+        uploader: {
+            upload: jest.fn().mockResolvedValue({
+                public_id: 'test_public_id',
+                secure_url: 'https://res.cloudinary.com/demo/image/upload/sample.jpg',
+            }),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+// Mock Resend
+jest.mock('resend', () => {
+    return {
+        Resend: jest.fn().mockImplementation(() => {
+            return {
+                emails: {
+                    send: jest.fn().mockResolvedValue({ id: 'test_id' }),
+                },
+            };
+        }),
+    };
+});
+
+jest.setTimeout(30000);
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    await mongoose.connect(uri);
+});
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+});
+
+afterEach(async () => {
+    await User.deleteMany({});
+    jest.clearAllMocks();
+});
+
+describe('Forgot Password Security Test', () => {
+    it('should return 200 OK generic message even if email does not exist (Account Enumeration Protection)', async () => {
+        const nonExistentEmail = 'ghost@example.com';
+
+        const response = await request(app)
+            .post('/api/v1/password/forgot')
+            .send({ email: nonExistentEmail });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.message).toBe("If that email address is in our database, we will send you an email to reset your password.");
+    });
+
+    it('should return 200 OK generic message if email exists', async () => {
+         const userData = {
+            name: 'Test User',
+            email: 'test@example.com',
+            password: 'password123',
+            avatar: {
+                public_id: 'test_id',
+                url: 'https://example.com/avatar.jpg'
+            }
+        };
+        await User.create(userData);
+
+        const response = await request(app)
+            .post('/api/v1/password/forgot')
+            .send({ email: userData.email });
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.message).toBe("If that email address is in our database, we will send you an email to reset your password.");
+    });
+});


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Account Enumeration in Forgot Password

🚨 Severity: MEDIUM
💡 Vulnerability: The `forgotPassword` endpoint previously returned a 404 error if the email was not found, allowing attackers to enumerate valid email addresses.
🎯 Impact: Attackers could build a list of valid users for phishing or brute-force attacks.
🔧 Fix: The endpoint now returns a generic success message ("If that email address is in our database...") regardless of whether the user exists.
✅ Verification: New test `backend/tests/security_account_enumeration.test.js` confirms that both existing and non-existent emails return 200 OK with the same message.

Also fixed a bug in `backend/models/userModel.js` regarding Mongoose async hooks.

---
*PR created automatically by Jules for task [9877452762474768219](https://jules.google.com/task/9877452762474768219) started by @parilsanghvi*