### PR TITLE
⚡ Bolt: Optimize stock update with bulkWrite

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -104,10 +104,17 @@ exports.updateOrder = catchAsyncErrors(async (req, res, next) => {
     }
 
 
-    if (req.body.status==="Shipped") {
-        await Promise.all(order.orderItems.map(async (item) => {
-            await updateStock(item.product, item.quantity)
-        }))
+    if (req.body.status === "Shipped") {
+        // Optimized: Use bulkWrite for atomic stock updates (1 DB call vs N+1)
+        const operations = order.orderItems.map((item) => ({
+            updateOne: {
+                filter: { _id: item.product },
+                update: { $inc: { stock: -item.quantity } }
+            }
+        }));
+        if (operations.length > 0) {
+            await Product.bulkWrite(operations);
+        }
     }
 
     order.orderStatus = req.body.status;
@@ -121,14 +128,6 @@ exports.updateOrder = catchAsyncErrors(async (req, res, next) => {
         success: true,
     });
 });
-
-async function updateStock(id, quantity) {
-    const product = await Product.findById(id);
-    product.stock = product.stock - quantity;
-    await product.save({
-        validateBeforeSave: false
-    })
-}
 
 // delete order --admin
 exports.deleteOrder = catchAsyncErrors(async (req, res, next) => {

--- a/backend/tests/integration/admin.test.js
+++ b/backend/tests/integration/admin.test.js
@@ -332,6 +332,9 @@ describe('Admin Integration Tests', () => {
 
                 const updated = await Order.findById(testOrder._id);
                 expect(updated.orderStatus).toBe('Shipped');
+
+                const updatedProduct = await Product.findById(testProduct._id);
+                expect(updatedProduct.stock).toBe(8);
             });
         });
 


### PR DESCRIPTION
Refactored `updateOrder` to use `Product.bulkWrite`, reducing database round-trips from O(N) to O(1) for stock updates. Also enhanced test coverage to verify stock decrement.

---
*PR created automatically by Jules for task [5546504698458631916](https://jules.google.com/task/5546504698458631916) started by @parilsanghvi*