### PR TITLE
⚡ Bolt: Optimize updateProfile by removing redundant user lookup

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -157,11 +157,11 @@ exports.updateProfile = catchAsyncErrors(async (req, res, next) => {
         email: req.body.email,
     }
     if (req.body.avatar !== "") {
-        const user = await User.findById(req.user.id)
         if (!req.body.avatar || req.body.avatar === "undefined") {
             return next(new ErrorHandler("Please upload a new avatar", 401))
         }
-        const imageId = user.avatar.public_id
+        // Optimized: Use req.user.avatar directly instead of redundant DB call
+        const imageId = req.user.avatar.public_id
         await cloudinary.v2.uploader.destroy(imageId);
         const myCloud = await cloudinary.v2.uploader.upload(req.body.avatar, {
             folder: "avatars",

--- a/backend/tests/unit/update_profile_optimization.test.js
+++ b/backend/tests/unit/update_profile_optimization.test.js
@@ -1,0 +1,67 @@
+const userController = require('../../controllers/userController');
+const User = require('../../models/userModel');
+const cloudinary = require('cloudinary');
+
+// Mock dependencies
+jest.mock('../../models/userModel');
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            destroy: jest.fn(),
+            upload: jest.fn(),
+        }
+    }
+}));
+jest.mock('../../middleware/catchAsyncErrors', () => (func) => (req, res, next) => func(req, res, next));
+jest.mock('../../utlis/errorhandler');
+
+describe('updateProfile Optimization', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        req = {
+            user: {
+                id: 'user123',
+                avatar: {
+                    public_id: 'old_public_id',
+                    url: 'old_url'
+                }
+            },
+            body: {
+                name: 'New Name',
+                email: 'new@example.com',
+                avatar: 'data:image/png;base64,newavatar'
+            }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        next = jest.fn();
+        jest.clearAllMocks();
+    });
+
+    it('should NOT call User.findById (optimized) when avatar is updated', async () => {
+        // Mock User.findById just in case (though it shouldn't be called)
+        User.findById.mockResolvedValue(null);
+
+        // Mock cloudinary upload
+        cloudinary.v2.uploader.upload.mockResolvedValue({
+            public_id: 'new_public_id',
+            secure_url: 'new_secure_url'
+        });
+
+        // Mock User.findByIdAndUpdate
+        User.findByIdAndUpdate.mockResolvedValue({});
+
+        await userController.updateProfile(req, res, next);
+
+        // Assert that User.findById IS NOT called (optimization verification)
+        expect(User.findById).not.toHaveBeenCalled();
+
+        // Verify other expected behaviors
+        expect(cloudinary.v2.uploader.destroy).toHaveBeenCalledWith('old_public_id');
+        expect(User.findByIdAndUpdate).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+});


### PR DESCRIPTION
*   💡 What: Removed `User.findById(req.user.id)` in `updateProfile` controller.
*   🎯 Why: `req.user` is already populated by `isAuthenticatedUser` middleware with the full user document. Re-fetching it is redundant and adds latency.
*   📊 Impact: Reduces database calls by 1 for every profile update request involving an avatar change.
*   🔬 Measurement: Verified with `backend/tests/unit/update_profile_optimization.test.js` which confirms `User.findById` is no longer called. All integration tests passed.

---
*PR created automatically by Jules for task [14607459974276679915](https://jules.google.com/task/14607459974276679915) started by @parilsanghvi*