### PR TITLE
⚡ Bolt: Optimize getAllOrders to conditionally calculate total revenue

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -80,14 +80,20 @@ exports.getAllOrders = catchAsyncErrors(async (req, res, next) => {
     // Optimized: Use estimatedDocumentCount() for faster counting of all documents
     const ordersCountPromise = Order.estimatedDocumentCount();
 
-    const aggregatePromise = Order.aggregate([
-        {
-            $group: {
-                _id: null,
-                totalAmount: { $sum: "$totalPrice" }
+    let aggregatePromise = Promise.resolve([]);
+
+    // Optimize: Only calculate total revenue when explicitly requested (e.g. for Dashboard)
+    // This avoids scanning the entire orders collection on every page load
+    if (req.query.calculateTotal === "true") {
+        aggregatePromise = Order.aggregate([
+            {
+                $group: {
+                    _id: null,
+                    totalAmount: { $sum: "$totalPrice" }
+                }
             }
-        }
-    ]);
+        ]);
+    }
 
     const apifeature = new Apifeatures(Order.find(), req.query)
         .pagiNation(resultPerPage);
@@ -101,15 +107,23 @@ exports.getAllOrders = catchAsyncErrors(async (req, res, next) => {
         ordersPromise
     ]);
 
-    const totalAmount = aggregateResult.length > 0 ? aggregateResult[0].totalAmount : 0;
+    let totalAmount;
+    if (req.query.calculateTotal === "true") {
+        totalAmount = aggregateResult.length > 0 ? aggregateResult[0].totalAmount : 0;
+    }
 
-    res.status(200).json({
+    const response = {
         success: true,
-        totalAmount,
         orders,
         totalOrders: ordersCount,
         resultPerPage,
-    });
+    };
+
+    if (totalAmount !== undefined) {
+        response.totalAmount = totalAmount;
+    }
+
+    res.status(200).json(response);
 });
 // update order status --admin
 exports.updateOrder = catchAsyncErrors(async (req, res, next) => {

--- a/backend/tests/orderController_getAllOrders.test.js
+++ b/backend/tests/orderController_getAllOrders.test.js
@@ -67,7 +67,8 @@ describe('getAllOrders Integration Test', () => {
 
     const req = {
       query: {
-        page: '1'
+        page: '1',
+        calculateTotal: 'true'
       }
     };
 
@@ -87,5 +88,66 @@ describe('getAllOrders Integration Test', () => {
     expect(responseData.totalOrders).toBe(3);
     expect(responseData.orders.length).toBe(3);
     expect(responseData.totalAmount).toBe(120 + 130 + 140);
+  });
+
+  it('should NOT return totalAmount when calculateTotal is not requested', async () => {
+    // Seed data with 'user' field
+    const userId = new mongoose.Types.ObjectId();
+    const orderData = {
+        shippingInfo: {
+            address: "123 Main St",
+            city: "City",
+            state: "State",
+            country: "Country",
+            pinCode: 123456,
+            phoneNo: 1234567890
+        },
+        orderItems: [{
+            name: "Product 1",
+            quantity: 1,
+            price: 100,
+            image: "image.jpg",
+            product: new mongoose.Types.ObjectId()
+        }],
+        user: userId,
+        paymentInfo: {
+            id: "payment_id",
+            status: "succeeded"
+        },
+        paidAt: new Date(),
+        itemsPrice: 100,
+        taxPrice: 10,
+        shippingPrice: 10,
+        totalPrice: 120,
+        orderStatus: "processing"
+    };
+
+    await Order.create([
+      { ...orderData, totalPrice: 120 },
+    ]);
+
+    const req = {
+      query: {
+        page: '1'
+        // calculateTotal is missing (undefined) or false
+      }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    const next = jest.fn();
+
+    await orderController.getAllOrders(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const responseData = res.json.mock.calls[0][0];
+
+    expect(responseData.success).toBe(true);
+    expect(responseData.totalOrders).toBe(1);
+    expect(responseData.orders.length).toBe(1);
+    expect(responseData.totalAmount).toBeUndefined();
   });
 });

--- a/frontend/src/component/Admin/Dashboard.jsx
+++ b/frontend/src/component/Admin/Dashboard.jsx
@@ -51,7 +51,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     dispatch(getAdminProduct());
-    dispatch(getAllOrders());
+    dispatch(getAllOrders({ calculateTotal: true }));
     dispatch(getAllUsers());
   }, [dispatch]);
 

--- a/frontend/src/features/orderSlice.js
+++ b/frontend/src/features/orderSlice.js
@@ -53,9 +53,19 @@ export const myOrders = createAsyncThunk(
 // Get All Orders (Admin)
 export const getAllOrders = createAsyncThunk(
     "order/getAllOrders",
-    async (page = 1, { rejectWithValue }) => {
+    async (arg = 1, { rejectWithValue }) => {
         try {
-            const { data } = await axios.get(`/api/v1/admin/orders?page=${page}`);
+            let page = 1;
+            let calculateTotal = false;
+
+            if (typeof arg === 'number') {
+                page = arg;
+            } else if (typeof arg === 'object') {
+                page = arg.page || 1;
+                calculateTotal = arg.calculateTotal || false;
+            }
+
+            const { data } = await axios.get(`/api/v1/admin/orders?page=${page}&calculateTotal=${calculateTotal}`);
             return data;
         } catch (error) {
             return rejectWithValue(error.response.data.message);
@@ -156,7 +166,10 @@ const orderSlice = createSlice({
             .addCase(getAllOrders.fulfilled, (state, action) => {
                 state.loading = false;
                 state.orders = action.payload.orders;
-                state.totalAmount = action.payload.totalAmount;
+                // Only update totalAmount if it's returned by the backend
+                if (action.payload.totalAmount !== undefined) {
+                    state.totalAmount = action.payload.totalAmount;
+                }
                 state.totalOrders = action.payload.totalOrders;
                 state.resultPerPage = action.payload.resultPerPage;
             })


### PR DESCRIPTION
⚡ **Bolt Optimization: Conditional Order Aggregation**

**Problem:**
Every time the admin order list was accessed (or paginated), the backend executed a `Order.aggregate` query to sum the `totalPrice` of ALL orders in the database. This O(N) operation runs on every request, causing significant performance degradation as the order volume grows.

**Solution:**
1.  Modified `getAllOrders` controller to make the aggregation conditional. It now only runs if `req.query.calculateTotal === 'true'`.
2.  Updated the frontend `getAllOrders` thunk to support passing this parameter.
3.  Updated `Dashboard.jsx` (which needs the total revenue) to explicitly request it.
4.  The `OrderList.jsx` (pagination view) now defaults to NOT requesting the total, skipping the expensive aggregation.

**Impact:**
-   **Reduces Database Load:** Eliminates full-collection scans on paginated order list views.
-   **Improves Response Time:** The API response for order listing is faster as it only queries the current page of orders.
-   **Scalability:** The admin panel remains responsive even with millions of orders.

**Verification:**
-   Added new test cases in `backend/tests/orderController_getAllOrders.test.js` verifying that `totalAmount` is returned only when requested.
-   Verified frontend build passes.


---
*PR created automatically by Jules for task [15397405322874889213](https://jules.google.com/task/15397405322874889213) started by @parilsanghvi*