### PR TITLE
🎨 Palette: Add tooltips to disabled cart buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-02-18 - Image Accessibility
 **Learning:** Found critical accessibility issues where image `alt` text was hardcoded to "ssa" or "Product", providing no value to screen readers.
 **Action:** Always bind `alt` text to dynamic content (e.g., `alt={item.name}`) when displaying product images or other dynamic content. Avoid placeholder strings in production code.
+
+## 2025-02-18 - Tooltips on Disabled Buttons
+**Learning:** Browsers often disable mouse events on `disabled` buttons, preventing tooltips from appearing. This codebase uses `pointer-events: none` on disabled buttons which exacerbates this.
+**Action:** To show tooltips on disabled actions, use `aria-disabled="true"` instead of `disabled` attribute, remove `pointer-events: none` from CSS, and wrap the button in a `Tooltip` component. Crucially, ensure the `onClick` handler explicitly checks the disabled condition since the button remains interactive.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4904,22 +4904,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/frontend/src/component/Cart/Cart.css
+++ b/frontend/src/component/Cart/Cart.css
@@ -74,12 +74,12 @@
   color: white;
 }
 
-.cartInput>button:disabled {
+.cartInput>button:disabled,
+.cartInput>button[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
   background-color: var(--color-surface);
   color: var(--color-text);
-  pointer-events: none;
 }
 
 .cartInput>input {

--- a/frontend/src/component/Cart/Cart.jsx
+++ b/frontend/src/component/Cart/Cart.jsx
@@ -3,7 +3,7 @@ import "./Cart.css";
 import CartItemCard from "./CartItemCard";
 import { useSelector, useDispatch } from "react-redux";
 import { addItemsToCart, removeItemsFromCart } from "../../features/cartSlice";
-import { Typography } from "@mui/material";
+import { Typography, Tooltip } from "@mui/material";
 import RemoveShoppingCartIcon from "@mui/icons-material/RemoveShoppingCart";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -65,34 +65,38 @@ const Cart = () => {
                 <div className="cartContainer" key={item.product}>
                   <CartItemCard item={item} deleteCartItems={deleteCartItems} />
                   <div className="cartInput">
-                    <button
-                      onClick={() =>
-                        decreaseQuantity(item.product, item.quantity)
-                      }
-                      disabled={item.quantity <= 1}
-                      aria-label="Decrease quantity"
-                    >
-                      -
-                    </button>
+                    <Tooltip title={item.quantity <= 1 ? "Minimum quantity is 1" : ""}>
+                      <button
+                        onClick={() =>
+                          decreaseQuantity(item.product, item.quantity)
+                        }
+                        aria-disabled={item.quantity <= 1}
+                        aria-label="Decrease quantity"
+                      >
+                        -
+                      </button>
+                    </Tooltip>
                     <input
                       type="number"
                       value={item.quantity}
                       readOnly
                       aria-label="Product quantity"
                     />
-                    <button
-                      onClick={() =>
-                        increaseQuantity(
-                          item.product,
-                          item.quantity,
-                          item.stock
-                        )
-                      }
-                      disabled={item.stock <= item.quantity}
-                      aria-label="Increase quantity"
-                    >
-                      +
-                    </button>
+                    <Tooltip title={item.stock <= item.quantity ? "Maximum stock reached" : ""}>
+                      <button
+                        onClick={() =>
+                          increaseQuantity(
+                            item.product,
+                            item.quantity,
+                            item.stock
+                          )
+                        }
+                        aria-disabled={item.stock <= item.quantity}
+                        aria-label="Increase quantity"
+                      >
+                        +
+                      </button>
+                    </Tooltip>
                   </div>
                   <p className="cartSubtotal">{`₹${item.price * item.quantity
                     }`}</p>


### PR DESCRIPTION
💡 What: Added tooltips to the quantity increase/decrease buttons in the Cart page.
🎯 Why: Users were confused when buttons were disabled without explanation (e.g., hitting stock limits).
📸 Before/After: Screenshots verified locally (buttons now show tooltips on hover).
♿ Accessibility: Improved by providing context for disabled states via tooltips and maintaining keyboard focusability with `aria-disabled`.

---
*PR created automatically by Jules for task [11646159423625547258](https://jules.google.com/task/11646159423625547258) started by @parilsanghvi*