### PR TITLE
🛡️ Sentinel: Add rate limiting to auth endpoints

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,9 @@
 const express = require('express');
 const app = express();
+
+// Enable trust proxy for rate limiting behind load balancers
+app.set('trust proxy', 1);
+
 const cookieParser = require("cookie-parser");
 const errorMidddleware = require('./middleware/error');
 const path = require("path")

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,0 +1,55 @@
+const rateLimiter = (windowMs, maxRequest, message) => {
+  const rateLimit = new Map();
+
+  // Clean up periodically (every 10 minutes)
+  const interval = setInterval(() => {
+    const now = Date.now();
+    for (const [ip, data] of rateLimit.entries()) {
+        // Remove entries older than the window
+        if (now - data.startTime > windowMs) {
+            rateLimit.delete(ip);
+        }
+    }
+  }, 10 * 60 * 1000);
+
+  // Ensure the interval doesn't prevent the process from exiting
+  if (interval.unref) interval.unref();
+
+  return (req, res, next) => {
+    // Skip rate limiting in test environment unless explicitly enabled
+    if (process.env.NODE_ENV === 'test' && !process.env.TEST_RATE_LIMIT) {
+      return next();
+    }
+
+    const ip = req.ip;
+    const now = Date.now();
+
+    if (!rateLimit.has(ip)) {
+      rateLimit.set(ip, { count: 1, startTime: now });
+      return next();
+    }
+
+    const requestData = rateLimit.get(ip);
+
+    // Check if window has expired
+    if (now - requestData.startTime > windowMs) {
+      // Window expired, reset
+      rateLimit.set(ip, { count: 1, startTime: now });
+      return next();
+    }
+
+    // Check if limit exceeded
+    if (requestData.count >= maxRequest) {
+      return res.status(429).json({
+        success: false,
+        message: message || "Too many requests, please try again later."
+      });
+    }
+
+    // Increment count
+    requestData.count++;
+    next();
+  };
+};
+
+module.exports = rateLimiter;

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -23,13 +23,14 @@ const {
 } = require("../middleware/auth")
 const validate = require("../middleware/validate");
 const { registerSchema, loginSchema, updateProfileSchema } = require("../schemas/userZodSchema");
+const rateLimiter = require("../middleware/rateLimiter");
 const router = express.Router()
 
 router.route("/register").post(upload.any(), validate(registerSchema), registerUser);
 
-router.route("/login").post(validate(loginSchema), loginUser)
+router.route("/login").post(rateLimiter(15 * 60 * 1000, 10, "Too many login attempts, please try again later"), validate(loginSchema), loginUser)
 
-router.route("/password/forgot").post(forgotPassword);
+router.route("/password/forgot").post(rateLimiter(15 * 60 * 1000, 5, "Too many password reset attempts, please try again later"), forgotPassword);
 
 router.route("/password/reset/:token").put(resetPassword);
 

--- a/backend/tests/security_rate_limit.test.js
+++ b/backend/tests/security_rate_limit.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+// Mock dependencies
+jest.mock('../utlis/sendEmail', () => jest.fn());
+jest.mock('cloudinary', () => ({
+    v2: {
+        config: jest.fn(),
+        uploader: {
+            upload: jest.fn().mockResolvedValue({ public_id: 'test_id', secure_url: 'test_url' }),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+let app;
+let mongoServer;
+
+describe('Security: Rate Limiting Middleware', () => {
+    jest.setTimeout(30000);
+
+    beforeAll(async () => {
+        // Enable rate limiting for test environment
+        process.env.TEST_RATE_LIMIT = 'true';
+
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+        process.env.DB_URI = uri;
+
+        // Connect to mongoose
+        if (mongoose.connection.readyState === 0) {
+            await mongoose.connect(uri);
+        }
+
+        // Import app AFTER setting env vars
+        app = require('../app');
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+        delete process.env.TEST_RATE_LIMIT;
+    });
+
+    it('should allow 10 login attempts and block the 11th', async () => {
+        const loginData = { email: 'test@example.com', password: 'password123' };
+
+        // 10 allowed attempts
+        for (let i = 0; i < 10; i++) {
+            const res = await request(app).post('/api/v1/login').send(loginData);
+            // Expect 401 (Invalid creds) or 200 (if user existed), but NOT 429
+            expect(res.status).not.toBe(429);
+        }
+
+        // 11th attempt - Blocked
+        const res = await request(app).post('/api/v1/login').send(loginData);
+        expect(res.status).toBe(429);
+        expect(res.body.success).toBe(false);
+        expect(res.body.message).toBe("Too many login attempts, please try again later");
+    });
+
+    it('should allow 5 forgot password attempts and block the 6th (Independent of Login)', async () => {
+        // Note: Even if login is blocked, forgot password should start fresh (different limiter instance)
+        const emailData = { email: 'test@example.com' };
+
+        // 5 allowed attempts
+        for (let i = 0; i < 5; i++) {
+            const res = await request(app).post('/api/v1/password/forgot').send(emailData);
+            expect(res.status).not.toBe(429);
+        }
+
+        // 6th attempt - Blocked
+        const res = await request(app).post('/api/v1/password/forgot').send(emailData);
+        expect(res.status).toBe(429);
+        // The forgotPassword controller might return different structure or message
+        // Based on userController.js: res.status(200).json({ success: true, message: ... })
+        // But rate limiter returns { success: false, message: ... }
+        expect(res.body.message).toBe("Too many password reset attempts, please try again later");
+    });
+});


### PR DESCRIPTION
Added rate limiting to `/login` and `/password/forgot` endpoints to prevent brute-force attacks. Implemented a custom in-memory rate limiter and enabled `trust proxy` for correct IP handling behind load balancers. Verified with new backend tests.

---
*PR created automatically by Jules for task [16368256774367334587](https://jules.google.com/task/16368256774367334587) started by @parilsanghvi*