### PR TITLE
🛡️ Sentinel: Fix IDOR in getSingleOrder endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,11 @@
 1. Always apply validation middleware to all public-facing routes, especially authentication-related ones.
 2. Ensure consistent use of `zod` schemas for all request bodies.
 3. Verify that new routes are added with appropriate validation middleware.
+
+## 2025-02-19 - IDOR in Order Details
+**Vulnerability:** The `getSingleOrder` endpoint fetched an order by ID but failed to verify if the authenticated user was the owner of that order. This allowed any authenticated user to access any other user's order details by guessing the order ID.
+**Learning:** Authentication is not Authorization. Even if a user is logged in (`isAuthenticatedUser`), they must only be allowed to access resources they own or have permission to view.
+**Prevention:**
+1. Always implement resource ownership checks in controllers for "get by ID" endpoints.
+2. Use a centralized authorization policy or middleware if possible.
+3. When unit testing controllers with `catchAsyncErrors`, mock the middleware to return the promise to ensure tests wait for async operations.

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -78,6 +78,12 @@ exports.getSingleOrder = catchAsyncErrors(async (req, res, next) => {
     if (!order) {
         return next(new ErrorHandler("order not found with this id", 404))
     }
+
+    // Security Fix: Prevent IDOR by ensuring user owns the order or is admin
+    if (order.user._id.toString() !== req.user._id.toString() && req.user.role !== "admin") {
+        return next(new ErrorHandler("order not found with this id", 404));
+    }
+
     res.status(200).json({
         success: true,
         order,

--- a/backend/tests/unit/security_getSingleOrder_IDOR.test.js
+++ b/backend/tests/unit/security_getSingleOrder_IDOR.test.js
@@ -1,0 +1,103 @@
+const Order = require("../../models/orderModel");
+const ErrorHandler = require("../../utlis/errorhandler");
+
+// Mock catchAsyncErrors before requiring the controller
+jest.mock("../../middleware/catchAsyncErrors", () => (func) => (req, res, next) => {
+  return Promise.resolve(func(req, res, next)).catch(next);
+});
+
+// Mock Order model
+jest.mock("../../models/orderModel");
+
+// Mock cloudinary to avoid import errors in productController (even though we test orderController,
+// if orderController imports anything that imports cloudinary indirectly)
+// orderController imports Product model, which might be fine.
+// But let's check orderController imports.
+// It imports Product model.
+// It imports apifeatures.
+// It imports errorhandler.
+
+// If we need to mock other dependencies, we should.
+// But let's try with minimal mocks first.
+
+const { getSingleOrder } = require("../../controllers/orderController");
+
+describe("getSingleOrder Security (IDOR)", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {
+      params: { id: "orderId123" },
+      user: { _id: "userB_ID", role: "user" }, // Default to User B
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("should fail (404) when user accesses another user's order", async () => {
+    // Mock order belonging to User A
+    const mockOrder = {
+      _id: "orderId123",
+      user: { _id: "userA_ID", name: "User A", email: "usera@example.com" },
+    };
+
+    // Chainable Mongoose mocks: findById -> populate -> lean -> returns mockOrder
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    const mockPopulate = jest.fn().mockReturnValue({ lean: mockLean });
+    Order.findById.mockReturnValue({ populate: mockPopulate });
+
+    await getSingleOrder(req, res, next);
+
+    // Expectation: Should fail because req.user._id (User B) != order.user._id (User A)
+    // Currently (before fix), this will FAIL the test because it returns 200.
+    // We assert that it SHOULD be unauthorized (404).
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+  });
+
+  it("should succeed when user accesses their own order", async () => {
+    req.user._id = "userA_ID"; // Same as order owner
+
+    const mockOrder = {
+      _id: "orderId123",
+      user: { _id: "userA_ID", name: "User A", email: "usera@example.com" },
+    };
+
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    const mockPopulate = jest.fn().mockReturnValue({ lean: mockLean });
+    Order.findById.mockReturnValue({ populate: mockPopulate });
+
+    await getSingleOrder(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      order: mockOrder,
+    });
+  });
+
+  it("should succeed when admin accesses another user's order", async () => {
+    req.user = { _id: "adminID", role: "admin" }; // Admin user
+
+    const mockOrder = {
+      _id: "orderId123",
+      user: { _id: "userA_ID", name: "User A", email: "usera@example.com" },
+    };
+
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    const mockPopulate = jest.fn().mockReturnValue({ lean: mockLean });
+    Order.findById.mockReturnValue({ populate: mockPopulate });
+
+    await getSingleOrder(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      order: mockOrder,
+    });
+  });
+});


### PR DESCRIPTION
Fixed an Insecure Direct Object Reference (IDOR) vulnerability in `backend/controllers/orderController.js` where authenticated users could access any order by ID.
- Added a check in `getSingleOrder` to verify `req.user._id` matches `order.user._id` or `req.user.role` is 'admin'.
- Added `backend/tests/unit/security_getSingleOrder_IDOR.test.js` to verify the fix using mocks.
- Updated `.jules/sentinel.md` with the new learning.

---
*PR created automatically by Jules for task [8859510918866534668](https://jules.google.com/task/8859510918866534668) started by @parilsanghvi*