### PR TITLE
Security: Add rate limiting to /register endpoint

### DIFF
--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -26,7 +26,7 @@ const { registerSchema, loginSchema, updateProfileSchema, forgotPasswordSchema, 
 const rateLimiter = require("../middleware/rateLimiter");
 const router = express.Router()
 
-router.route("/register").post(upload.any(), validate(registerSchema), registerUser);
+router.route("/register").post(rateLimiter(15 * 60 * 1000, 5, "Too many registration attempts, please try again later"), upload.any(), validate(registerSchema), registerUser);
 
 router.route("/login").post(rateLimiter(15 * 60 * 1000, 10, "Too many login attempts, please try again later"), validate(loginSchema), loginUser)
 

--- a/backend/tests/security_register_rate_limit.test.js
+++ b/backend/tests/security_register_rate_limit.test.js
@@ -1,0 +1,84 @@
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+const app = require('../app');
+const User = require('../models/userModel');
+
+// Enable rate limiting for this test suite
+process.env.TEST_RATE_LIMIT = 'true';
+
+let mongoServer;
+
+// Mock Cloudinary
+jest.mock('cloudinary', () => ({
+    v2: {
+        config: jest.fn(),
+        uploader: {
+            upload: jest.fn().mockResolvedValue({
+                public_id: 'test_public_id',
+                secure_url: 'https://res.cloudinary.com/demo/image/upload/sample.jpg',
+            }),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+// Mock Resend
+jest.mock('resend', () => {
+    return {
+        Resend: jest.fn().mockImplementation(() => {
+            return {
+                emails: {
+                    send: jest.fn().mockResolvedValue({ id: 'test_id' }),
+                },
+            };
+        }),
+    };
+});
+
+beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    await mongoose.connect(uri);
+});
+
+afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    // Reset env var
+    delete process.env.TEST_RATE_LIMIT;
+});
+
+afterEach(async () => {
+    await User.deleteMany({});
+    jest.clearAllMocks();
+});
+
+describe('Security: Rate Limiting on Registration', () => {
+    it('should block excessive registration attempts from the same IP', async () => {
+        const userData = {
+            name: 'Rate Limit User',
+            password: 'password123',
+            avatar: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        };
+
+        // Attempt 5 registrations (assuming limit will be 5)
+        for (let i = 0; i < 5; i++) {
+            const res = await request(app)
+                .post('/api/v1/register')
+                .send({ ...userData, email: `ratelimit${i}@example.com` });
+
+            // Should succeed (201)
+            expect(res.status).toBe(201);
+        }
+
+        // The 6th attempt should be blocked
+        const res = await request(app)
+            .post('/api/v1/register')
+            .send({ ...userData, email: 'blocked@example.com' });
+
+        // This assertion will fail until the fix is applied
+        expect(res.status).toBe(429);
+        expect(res.body.message).toMatch(/Too many registration attempts/i);
+    }, 30000); // 30s timeout
+});


### PR DESCRIPTION
This PR enhances security by adding rate limiting to the user registration endpoint. This prevents account creation spam and mitigates Denial of Service (DoS) risks associated with large file uploads (avatars) by blocking excessive requests before they reach the multipart parser.

**Changes:**
- `backend/routes/userRoute.js`: Added `rateLimiter` middleware to the `/register` route with a limit of 5 requests per 15 minutes.
- `backend/tests/security_register_rate_limit.test.js`: Added a new integration test to verify that excessive registration attempts are blocked with a 429 status code.

**Verification:**
- New test `backend/tests/security_register_rate_limit.test.js` passes.
- Existing `backend/tests/integration/auth.test.js` passes.

---
*PR created automatically by Jules for task [4226255688780890157](https://jules.google.com/task/4226255688780890157) started by @parilsanghvi*