### PR TITLE
⚡ Bolt: optimize getAllProducts count query

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -79,7 +79,17 @@ exports.getAllProducts = catchAsyncErrors(async (req, res, next) => {
         .search()
         .filter();
 
-    const filteredProductsCountPromise = apifeature.query.clone().countDocuments();
+    // Optimized: Only count filtered documents if filters are applied
+    let filteredProductsCountPromise;
+    const { keyword, page, limit, ...filters } = req.query;
+    const hasSearch = typeof keyword === 'string' && keyword.trim() !== "";
+    const hasFilters = Object.keys(filters).length > 0;
+
+    if (!hasSearch && !hasFilters) {
+        filteredProductsCountPromise = Promise.resolve(productsCount);
+    } else {
+        filteredProductsCountPromise = apifeature.query.clone().countDocuments();
+    }
 
     apifeature.pagiNation(resultPerPage);
 

--- a/backend/tests/unit/product_count_optimization.test.js
+++ b/backend/tests/unit/product_count_optimization.test.js
@@ -1,0 +1,103 @@
+
+const productController = require('../../controllers/productController');
+const Product = require('../../models/productModel');
+const Apifeatures = require('../../utlis/apifeatures');
+
+// Mock catchAsyncErrors
+jest.mock('../../middleware/catchAsyncErrors', () => (func) => (req, res, next) => func(req, res, next).catch(next));
+
+// Mock Mongoose Product model
+jest.mock('../../models/productModel');
+
+describe('Product Count Optimization', () => {
+    let req, res, next;
+    let mockQuery;
+
+    beforeEach(() => {
+        // Reset mocks
+        jest.clearAllMocks();
+
+        // Setup mock query chain
+        mockQuery = {
+            find: jest.fn().mockReturnThis(),
+            sort: jest.fn().mockReturnThis(),
+            skip: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            lean: jest.fn().mockResolvedValue([]), // productsPromise
+            clone: jest.fn().mockReturnThis(),
+            countDocuments: jest.fn().mockResolvedValue(5), // filteredProductsCount
+        };
+
+        // Mock Product methods
+        Product.find.mockReturnValue(mockQuery);
+        Product.estimatedDocumentCount.mockResolvedValue(10); // productsCount
+
+        // Setup Request/Response
+        req = {
+            query: {}
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        next = jest.fn();
+    });
+
+    it('should use countDocuments() when filters are applied (keyword)', async () => {
+        req.query = { keyword: 'apple' };
+
+        await productController.getAllProducts(req, res, next);
+
+        if (next.mock.calls.length > 0) {
+            console.error('Error in controller:', next.mock.calls[0][0]);
+        }
+
+        expect(Product.estimatedDocumentCount).toHaveBeenCalled();
+        expect(mockQuery.clone).toHaveBeenCalled();
+        expect(mockQuery.countDocuments).toHaveBeenCalled();
+
+        // filteredProductsCount should be from countDocuments (5)
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            filteredProductsCount: 5,
+            productsCount: 10
+        }));
+    });
+
+    it('should use countDocuments() when filters are applied (category)', async () => {
+        req.query = { category: 'electronics' };
+
+        await productController.getAllProducts(req, res, next);
+
+        expect(Product.estimatedDocumentCount).toHaveBeenCalled();
+        expect(mockQuery.clone).toHaveBeenCalled();
+        expect(mockQuery.countDocuments).toHaveBeenCalled();
+
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            filteredProductsCount: 5,
+            productsCount: 10
+        }));
+    });
+
+    it('should SKIP countDocuments() when NO filters are applied', async () => {
+        req.query = { page: '1' }; // Pagination only
+
+        await productController.getAllProducts(req, res, next);
+
+        expect(Product.estimatedDocumentCount).toHaveBeenCalled();
+
+        // This is the optimization we expect:
+        // mockQuery.countDocuments should NOT be called if we optimize it.
+        // BUT currently (before optimization), it IS called.
+        // So initially, this test should FAIL or we assert it IS called to prove baseline.
+
+        // Optimization: countDocuments should NOT be called
+        expect(mockQuery.countDocuments).not.toHaveBeenCalled();
+
+        // And we should still get the correct count (from estimatedDocumentCount which is 10)
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            filteredProductsCount: 10,
+            productsCount: 10
+        }));
+    });
+});


### PR DESCRIPTION
⚡ Bolt: optimize getAllProducts count query

💡 What:
Modified `getAllProducts` controller to check if `req.query` contains any filtering parameters (keyword, price, category, etc.). If no filters are present, it skips the `apifeature.query.clone().countDocuments()` call and reuses the already fetched `productsCount` (which uses `estimatedDocumentCount()`).

🎯 Why:
`countDocuments()` performs a collection scan (or index scan) which is O(N). `estimatedDocumentCount()` relies on collection metadata and is O(1). For the default view (landing page, all products), running a full count is unnecessary overhead.

📊 Impact:
Reduces database operations by 1 per request for the most common "view all" scenario.
On a large dataset (e.g., 100k products), this eliminates a query that could take 50-100ms+.

🔬 Measurement:
Verified with `backend/tests/unit/product_count_optimization.test.js` which spies on the Mongoose query methods to ensure `countDocuments` is NOT called when filters are absent, and IS called when filters are present.
Verified regression with `backend/tests/productController_getAllProducts.test.js`.

---
*PR created automatically by Jules for task [12626570845873551842](https://jules.google.com/task/12626570845873551842) started by @parilsanghvi*