### PR TITLE
🎨 Palette: Add Reset Filters button and category toggle

### DIFF
--- a/frontend/src/__tests__/ProductsEmpty.test.jsx
+++ b/frontend/src/__tests__/ProductsEmpty.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import Products from '../component/Product/Products';
+
+// Mock Redux
+const mockDispatch = vi.fn();
+vi.mock('react-redux', () => ({
+    ...vi.importActual('react-redux'),
+    useDispatch: () => mockDispatch,
+    useSelector: (selector) => selector({
+        product: {
+            loading: false,
+            error: null,
+            products: [], // Empty products
+            productsCount: 0,
+            resultPerPage: 8,
+            filteredProductsCount: 0
+        }
+    }),
+}));
+
+// Mock Notistack
+vi.mock('notistack', () => ({
+    useSnackbar: () => ({
+        enqueueSnackbar: vi.fn()
+    })
+}));
+
+// Mock Router
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useParams: () => ({ keyword: '' }),
+    };
+});
+
+// Mock children
+vi.mock('../component/Home/ProductCard', () => ({
+    default: (props) => <div>{props.product.name}</div>,
+}));
+vi.mock('../component/layout/MetaData', () => ({
+    default: () => <div>MetaData</div>,
+}));
+
+describe('Products Component - Empty State', () => {
+
+    it('renders "No Products Found" and "Reset Filters" button when product list is empty', () => {
+        render(
+            <BrowserRouter>
+                <Products />
+            </BrowserRouter>
+        );
+
+        expect(screen.getByText('No Products Found')).toBeInTheDocument();
+        const resetButton = screen.getByRole('button', { name: /Reset Filters/i });
+        expect(resetButton).toBeInTheDocument();
+
+        // Click the button
+        fireEvent.click(resetButton);
+
+        // Since resetFilters updates state, it triggers useEffect which dispatches getProduct
+        // The getProduct action is dispatched with default values.
+        // We can check if dispatch was called.
+        expect(mockDispatch).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/component/Product/Products.jsx
+++ b/frontend/src/component/Product/Products.jsx
@@ -7,6 +7,7 @@ import ProductCard from '../Home/ProductCard'
 import Pagination from "@mui/material/Pagination"
 import Slider from "@mui/material/Slider"
 import Typography from "@mui/material/Typography"
+import Button from "@mui/material/Button"
 import SearchOffIcon from "@mui/icons-material/SearchOff";
 import MetaData from "../layout/MetaData";
 import useErrorNotification from "../../hooks/useErrorNotification";
@@ -37,6 +38,13 @@ const Products = () => {
     }
     const priceHandler = (event, newPrice) => {
         setPrice(newPrice);
+        setCurrentPage(1);
+    }
+
+    const resetFilters = () => {
+        setPrice([0, 25000]);
+        setCategory("");
+        setRating(0);
         setCurrentPage(1);
     }
 
@@ -112,13 +120,21 @@ const Products = () => {
                                     <li className='category-link'
                                         key={cat}
                                         onClick={() => {
-                                            setCategory(cat);
+                                            if (category === cat) {
+                                                setCategory("");
+                                            } else {
+                                                setCategory(cat);
+                                            }
                                             setCurrentPage(1);
                                         }}
                                         onKeyDown={(e) => {
                                             if (e.key === 'Enter' || e.key === ' ') {
                                                 e.preventDefault();
-                                                setCategory(cat);
+                                                if (category === cat) {
+                                                    setCategory("");
+                                                } else {
+                                                    setCategory(cat);
+                                                }
                                                 setCurrentPage(1);
                                             }
                                         }}
@@ -180,6 +196,14 @@ const Products = () => {
                                 <div className="noProducts">
                                     <SearchOffIcon />
                                     <Typography>No Products Found</Typography>
+                                    <Button
+                                        variant="outlined"
+                                        color="primary"
+                                        onClick={resetFilters}
+                                        sx={{ marginTop: '1rem', fontFamily: 'var(--font-heading)' }}
+                                    >
+                                        Reset Filters
+                                    </Button>
                                 </div>
                             )}
 


### PR DESCRIPTION
Added a "Reset Filters" button to the "No Products Found" state in the product listing page. This allows users to quickly clear all filters (price, category, ratings) and return to the default view. Also improved the category filter to allow users to deselect the currently active category by clicking it again. Verified with a new unit test and Playwright frontend verification.

---
*PR created automatically by Jules for task [18353243728622811224](https://jules.google.com/task/18353243728622811224) started by @parilsanghvi*