### PR TITLE
🎨 Palette: Add Clear Filters button to Products page

### DIFF
--- a/frontend/src/__tests__/Products_UX.test.jsx
+++ b/frontend/src/__tests__/Products_UX.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import Products from '../component/Product/Products';
+
+// Mock Redux
+const mockDispatch = vi.fn();
+vi.mock('react-redux', () => ({
+    ...vi.importActual('react-redux'),
+    useDispatch: () => mockDispatch,
+    useSelector: (selector) => selector({
+        product: {
+            loading: false,
+            error: null,
+            products: [],
+            productsCount: 0,
+            resultPerPage: 8,
+            filteredProductsCount: 0
+        }
+    }),
+}));
+
+// Mock Notistack
+vi.mock('notistack', () => ({
+    useSnackbar: () => ({
+        enqueueSnackbar: vi.fn()
+    })
+}));
+
+// Mock Router
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useParams: () => ({ keyword: '' }),
+    };
+});
+
+// Mock children components to avoid complex rendering and ensure isolation
+vi.mock('../component/Home/ProductCard', () => ({
+    default: () => <div>ProductCard</div>,
+}));
+vi.mock('../component/layout/MetaData', () => ({
+    default: () => <div>MetaData</div>,
+}));
+
+describe('Products Component UX', () => {
+
+    it('shows "Clear Filters" button when filters are active and hides it when clicked', async () => {
+        render(
+            <BrowserRouter>
+                <Products />
+            </BrowserRouter>
+        );
+
+        // Initially, "Clear Filters" should not be visible because default state matches filter reset
+        const clearButtonQuery = screen.queryByRole('button', { name: /clear all filters/i });
+        expect(clearButtonQuery).not.toBeInTheDocument();
+
+        // Apply a filter (e.g., select a category)
+        // Note: The category list items have role="button" so we can find them
+        const categoryLink = screen.getByText('Laptop');
+        fireEvent.click(categoryLink);
+
+        // Now "Clear Filters" should be visible
+        // We use findByRole to wait for the re-render if necessary
+        const clearButton = await screen.findByRole('button', { name: /clear all filters/i });
+        expect(clearButton).toBeInTheDocument();
+
+        // Click "Clear Filters"
+        fireEvent.click(clearButton);
+
+        // "Clear Filters" should disappear
+        await waitFor(() => {
+            expect(screen.queryByRole('button', { name: /clear all filters/i })).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/component/Product/Products.css
+++ b/frontend/src/component/Product/Products.css
@@ -33,6 +33,12 @@
     color: var(--color-text);
 }
 
+.clear-filters-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+}
+
 .products {
     flex: 1;
     display: grid;

--- a/frontend/src/component/Product/Products.jsx
+++ b/frontend/src/component/Product/Products.jsx
@@ -24,11 +24,13 @@ const categories = [
     "SmartPhones",
 ]
 
+const MAX_PRICE = 25000;
+
 const Products = () => {
     const dispatch = useDispatch()
     const [ratings, setRating] = useState(0)
     const [currentPage, setCurrentPage] = useState(1)
-    const [price, setPrice] = useState([0, 25000])
+    const [price, setPrice] = useState([0, MAX_PRICE])
     const [category, setCategory] = useState("")
     const { products, loading, error, productsCount, resultPerPage, filteredProductsCount } = useSelector((state) => state.product)
     const { keyword } = useParams();
@@ -42,7 +44,7 @@ const Products = () => {
     }
 
     const resetFilters = () => {
-        setPrice([0, 25000]);
+        setPrice([0, MAX_PRICE]);
         setCategory("");
         setRating(0);
         setCurrentPage(1);
@@ -54,6 +56,8 @@ const Products = () => {
     useEffect(() => {
         dispatch(getProduct({ keyword, currentPage, price, category, ratings }));
     }, [dispatch, keyword, currentPage, price, category, ratings]);
+
+    const isFiltered = price[0] !== 0 || price[1] !== MAX_PRICE || category !== "" || ratings > 0;
 
     return (
         <Fragment>
@@ -69,6 +73,25 @@ const Products = () => {
                             animate={{ x: 0, opacity: 1 }}
                             transition={{ duration: 0.5 }}
                         >
+                            {isFiltered && (
+                                <div className="clear-filters-container">
+                                    <Button
+                                        variant="text"
+                                        color="secondary"
+                                        size="small"
+                                        onClick={resetFilters}
+                                        aria-label="Clear all filters"
+                                        sx={{
+                                            textTransform: 'none',
+                                            padding: '4px 8px',
+                                            fontFamily: 'var(--font-heading)',
+                                            color: 'var(--color-primary)'
+                                        }}
+                                    >
+                                        Clear Filters
+                                    </Button>
+                                </div>
+                            )}
                             <Typography variant="h6" className="filter-heading" id="range-slider">Price Range</Typography>
                             <Slider
                                 value={price}
@@ -77,7 +100,7 @@ const Products = () => {
                                 valueLabelDisplay='auto'
                                 aria-labelledby='range-slider'
                                 min={0}
-                                max={25000}
+                                max={MAX_PRICE}
                                 sx={{
                                     marginTop: '1rem',
                                     marginBottom: '2rem',
@@ -159,6 +182,7 @@ const Products = () => {
                                     min={0}
                                     max={5}
                                     valueLabelDisplay='auto'
+                                    aria-label="Minimum Rating"
                                     sx={{
                                         marginTop: '0.5rem',
                                         color: 'var(--color-primary)',


### PR DESCRIPTION
Added a "Clear Filters" button to the product listing sidebar that appears when filters (price, category, ratings) are active. This improves the user experience by allowing users to easily reset their search criteria.

Changes:
- `frontend/src/component/Product/Products.jsx`: Added `isFiltered` logic and the clear button. Refactored price range to use `MAX_PRICE`. Added `aria-label` to Rating slider.
- `frontend/src/component/Product/Products.css`: Added styles for the clear button container.
- `frontend/src/__tests__/Products_UX.test.jsx`: Added a new test file to verify the clear filters functionality.

Verified with:
- Existing tests: `cd frontend && pnpm test` (all passed).
- New test: `frontend/src/__tests__/Products_UX.test.jsx` (passed).
- Manual verification via Playwright script (confirmed button visibility).

---
*PR created automatically by Jules for task [16719804062017516903](https://jules.google.com/task/16719804062017516903) started by @parilsanghvi*