### PR TITLE
🧹 cleanup unused React import in App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,11 @@
 import './App.css';
 import "@fontsource/archivo-black";
 import "@fontsource/space-mono";
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense, lazy } from "react";
 import Header from "./component/layout/Header/Header"
 import Footer from "./component/layout/Footer/Footer"
 import Loader from "./component/layout/Loader";
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import React, { Suspense, lazy } from 'react';
 import Home from "./component/Home/Home"
 import ProductDetails from "./component/Product/ProductDetails"
 import Products from "./component/Product/Products"


### PR DESCRIPTION
This change addresses a code health issue in `frontend/src/App.jsx` where `React` was imported but not used, and imports from the `react` package were split across multiple statements.

Changes:
- Combined `import { useEffect, useState } from "react";` and `import React, { Suspense, lazy } from 'react';` into a single statement.
- Removed the unused default `React` import.

These improvements align with modern React best practices and keep the codebase clean.

---
*PR created automatically by Jules for task [2764737915370323833](https://jules.google.com/task/2764737915370323833) started by @parilsanghvi*