### PR TITLE
Cleanup: Remove commented-out code in App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,7 +61,7 @@ function App() {
     store.dispatch(loadUser());
     getStripeApiKey();
   }, [])
-  // window.addEventListener("contextmenu", (e) => e.preventDefault());
+
   return (
     <Router>
       <Header />


### PR DESCRIPTION
This PR removes a commented-out event listener for `contextmenu` in `frontend/src/App.jsx`. The code was dead and removing it improves maintainability and readability. No functional changes were made.
Verified by running frontend tests and ensuring the build passes.
Cleaned up accidental lockfile changes during development.

---
*PR created automatically by Jules for task [4963511059702245063](https://jules.google.com/task/4963511059702245063) started by @parilsanghvi*