### PR TITLE
test: add unit tests for authorizedRoles middleware

### DIFF
--- a/backend/tests/unit/auth_middleware.test.js
+++ b/backend/tests/unit/auth_middleware.test.js
@@ -1,4 +1,4 @@
-const { isAuthenticatedUser } = require('../../middleware/auth');
+const { isAuthenticatedUser, authorizedRoles } = require('../../middleware/auth');
 const User = require('../../models/userModel');
 const jwt = require('jsonwebtoken');
 const ErrorHandler = require('../../utlis/errorhandler');
@@ -33,5 +33,39 @@ describe('Auth Middleware', () => {
         // Expect next to be called with an ErrorHandler
         expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(next.mock.calls[0][0].message).toMatch(/User no longer exists|Please login/i);
+    });
+
+    describe('authorizedRoles', () => {
+        let req, res, next;
+
+        beforeEach(() => {
+            req = {
+                user: {
+                    role: 'user'
+                }
+            };
+            res = {};
+            next = jest.fn();
+        });
+
+        it('should call next() if user role is authorized', () => {
+            req.user.role = 'admin';
+            authorizedRoles('admin')(req, res, next);
+            expect(next).toHaveBeenCalledWith();
+        });
+
+        it('should call next(ErrorHandler) if user role is not authorized', () => {
+            req.user.role = 'user';
+            authorizedRoles('admin')(req, res, next);
+            expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+            expect(next.mock.calls[0][0].statusCode).toBe(403);
+            expect(next.mock.calls[0][0].message).toMatch(/is not allowed to access this resource/);
+        });
+
+        it('should allow multiple roles', () => {
+            req.user.role = 'editor';
+            authorizedRoles('admin', 'editor')(req, res, next);
+            expect(next).toHaveBeenCalledWith();
+        });
     });
 });


### PR DESCRIPTION
Added comprehensive unit tests for the `authorizedRoles` middleware in `backend/middleware/auth.js`.

**Changes:**
- Modified `backend/tests/unit/auth_middleware.test.js` to import `authorizedRoles`.
- Added a `describe` block for `authorizedRoles` with three test cases:
    1.  `should call next() if user role is authorized`: Verifies access is granted.
    2.  `should call next(ErrorHandler) if user role is not authorized`: Verifies access is denied with 403 status.
    3.  `should allow multiple roles`: Verifies access is granted when one of multiple allowed roles is present.

**Testing:**
- Ran `pnpm jest backend/tests/unit/auth_middleware.test.js --config backend/jest.config.js` and verified all tests pass.
- Ran `pnpm run test:backend` to ensure no regressions in unit tests (integration tests had environment issues unrelated to changes).

---
*PR created automatically by Jules for task [3073149412418420934](https://jules.google.com/task/3073149412418420934) started by @parilsanghvi*