### PR TITLE
Add unit tests for User model security methods

### DIFF
--- a/backend/tests/user_model_security.test.js
+++ b/backend/tests/user_model_security.test.js
@@ -1,5 +1,7 @@
 const mongoose = require('mongoose');
 const User = require('../models/userModel');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 
 describe('User Model Security', () => {
     it('should set a valid resetPasswordExpire date', () => {
@@ -22,5 +24,39 @@ describe('User Model Security', () => {
             expect(!isNaN(user.resetPasswordExpire.getTime())).toBe(true);
             expect(user.resetPasswordExpire.getTime()).toBeGreaterThan(Date.now());
         }
+    });
+
+    it('should generate a valid JWT token', () => {
+        const user = new User({
+            name: 'test',
+            email: 'test@test.com',
+            password: 'password',
+            avatar: { public_id: 'id', url: 'url' }
+        });
+
+        const token = user.getJWTToken();
+        expect(typeof token).toBe('string');
+
+        // Verify the token
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        expect(decoded.id).toBe(user._id.toString());
+    });
+
+    it('should correctly compare passwords', async () => {
+        const user = new User({
+            name: 'test',
+            email: 'test@test.com',
+            password: 'password',
+            avatar: { public_id: 'id', url: 'url' }
+        });
+
+        const salt = await bcrypt.genSalt(10);
+        user.password = await bcrypt.hash('password123', salt);
+
+        const isMatch = await user.comparePassword('password123');
+        const isNotMatch = await user.comparePassword('wrongpassword');
+
+        expect(isMatch).toBe(true);
+        expect(isNotMatch).toBe(false);
     });
 });


### PR DESCRIPTION
Added unit tests for `getJWTToken` and `comparePassword` methods in `backend/models/userModel.js` to ensure security-critical functions are tested. Verified that tests pass and fail as expected.

---
*PR created automatically by Jules for task [17708297395342159062](https://jules.google.com/task/17708297395342159062) started by @parilsanghvi*