### PR TITLE
🔒 Security Fix: Remove JWT from JSON response to prevent exposure

### DIFF
--- a/backend/tests/jwtToken.test.js
+++ b/backend/tests/jwtToken.test.js
@@ -47,4 +47,14 @@ describe('JWT Token Utility', () => {
 
         expect(options).toHaveProperty('secure', false);
     });
+
+    it('should NOT include token in JSON response', () => {
+        sendToken(user, 200, res);
+
+        const jsonCall = res.json.mock.calls[0][0];
+
+        expect(jsonCall).not.toHaveProperty('token');
+        expect(jsonCall).toHaveProperty('success', true);
+        expect(jsonCall).toHaveProperty('user');
+    });
 });

--- a/backend/utlis/jwtToken.js
+++ b/backend/utlis/jwtToken.js
@@ -13,7 +13,6 @@ const sendToken = (user, statusCode, res) => {
     res.status(statusCode).cookie("token",token,options).json({
         success:true,
         user,
-        token,
     })
 }
 module.exports= sendToken;


### PR DESCRIPTION
This PR addresses a security vulnerability where the JWT token was being returned in the JSON response body, in addition to being set as an HttpOnly cookie. This redundancy exposed the token to potential XSS attacks.

**Changes:**
- Modified `backend/utlis/jwtToken.js` to remove `token` from the `res.json()` object.
- Added a unit test in `backend/tests/jwtToken.test.js` to verify that the token is NOT present in the JSON response.

**Verification:**
- Ran `backend/tests/jwtToken.test.js` -> Passed.
- Ran `backend/tests/integration/auth_deleted_user.test.js` -> Passed (confirms auth works via cookies).
- Verified no other tests rely on `res.body.token`.


---
*PR created automatically by Jules for task [10700910462458689256](https://jules.google.com/task/10700910462458689256) started by @parilsanghvi*