### PR TITLE
🔒 Fix Payment Verification Vulnerability in Order Creation

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -5,6 +5,8 @@ const ErrorHandler = require("../utlis/errorhandler");
 const catchAsyncErrors = require("../middleware/catchAsyncErrors");
 const Apifeatures = require("../utlis/apifeatures");
 
+const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
 // create new order
 exports.newOrder = catchAsyncErrors(async (req, res, next) => {
     const {
@@ -52,6 +54,33 @@ exports.newOrder = catchAsyncErrors(async (req, res, next) => {
 
     if (isNaN(totalPrice) || Math.abs(Number(totalPrice) - calculatedTotalPrice) > 0.01) {
         return next(new ErrorHandler("Total price mismatch detected. Please refresh and try again.", 400));
+    }
+
+    // Security Fix: Verify payment with Stripe
+    if (!paymentInfo || !paymentInfo.id) {
+        return next(new ErrorHandler("Payment Information is missing", 400));
+    }
+
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentInfo.id);
+
+    if (paymentIntent.status !== "succeeded") {
+        return next(new ErrorHandler("Payment not verified", 400));
+    }
+
+    if (paymentInfo.status !== "succeeded") {
+        return next(new ErrorHandler("Payment status mismatch", 400));
+    }
+
+    // Verify amount matches (Stripe amount is in smallest currency unit, e.g., paise)
+    // calculatedTotalPrice is in major unit (e.g. Rupees)
+    if (paymentIntent.amount !== Math.round(calculatedTotalPrice * 100)) {
+        return next(new ErrorHandler("Payment amount mismatch", 400));
+    }
+
+    // Check if payment is already used (Replay Attack Prevention)
+    const existingOrder = await Order.findOne({ "paymentInfo.id": paymentInfo.id });
+    if (existingOrder) {
+        return next(new ErrorHandler("Payment already used", 400));
     }
 
     const order = await Order.create({

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
+    rootDir: '..',
     testEnvironment: 'node',
     verbose: true,
-    testMatch: ['**/backend/tests/**/*.test.js'],
+    testMatch: ['<rootDir>/backend/tests/**/*.test.js'],
     forceExit: true,
-    setupFiles: ['<rootDir>/tests/setupEnv.js'],
+    setupFiles: ['<rootDir>/backend/tests/setupEnv.js'],
 };

--- a/backend/tests/integration/order.test.js
+++ b/backend/tests/integration/order.test.js
@@ -24,6 +24,18 @@ jest.mock('cloudinary', () => ({
     },
 }));
 
+// Mock Stripe
+jest.mock('stripe', () => {
+    return jest.fn().mockReturnValue({
+        paymentIntents: {
+            retrieve: jest.fn().mockResolvedValue({
+                status: 'succeeded',
+                amount: 43600 // Matches itemsPrice=200, tax=36, shipping=200, total=436 * 100
+            })
+        }
+    });
+});
+
 beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const uri = mongoServer.getUri();
@@ -91,7 +103,7 @@ describe('Order Integration Tests', () => {
             }],
             paymentInfo: {
                 id: 'pay_test_123',
-                status: 'success'
+                status: 'succeeded'
             },
             paidAt: Date.now(),
             itemsPrice: 200,
@@ -143,7 +155,7 @@ describe('Order Integration Tests', () => {
                     product: testProduct._id
                 }],
                 user: testUser._id,
-                paymentInfo: { id: 'pay_123', status: 'success' },
+                paymentInfo: { id: 'pay_123', status: 'succeeded' },
                 paidAt: Date.now(),
                 itemsPrice: 100,
                 taxPrice: 10,
@@ -191,7 +203,7 @@ describe('Order Integration Tests', () => {
                     product: testProduct._id
                 }],
                 user: testUser._id,
-                paymentInfo: { id: 'pay_123', status: 'success' },
+                paymentInfo: { id: 'pay_123', status: 'succeeded' },
                 paidAt: Date.now(),
                 itemsPrice: 100,
                 taxPrice: 10,

--- a/backend/tests/security_payment_verification.test.js
+++ b/backend/tests/security_payment_verification.test.js
@@ -1,0 +1,149 @@
+const Order = require('../models/orderModel');
+const Product = require('../models/productModel');
+const ErrorHandler = require('../utlis/errorhandler');
+
+// Mock dependencies
+jest.mock('../models/orderModel');
+jest.mock('../models/productModel');
+jest.mock('../middleware/catchAsyncErrors', () => (func) => (req, res, next) => func(req, res, next));
+
+// Mock Stripe
+jest.mock('stripe', () => {
+    return jest.fn().mockReturnValue({
+        paymentIntents: {
+            retrieve: jest.fn()
+        }
+    });
+});
+
+const stripe = require('stripe');
+// Import controller AFTER mocking stripe so it picks up the mock
+const orderController = require('../controllers/orderController');
+
+// Capture the mock instance immediately, before any tests run or mocks are cleared
+// The controller calls stripe() on load, so results[0] holds the instance used by the controller
+const stripeInstance = stripe.mock.results[0].value;
+const mockRetrieve = stripeInstance.paymentIntents.retrieve;
+
+describe('Order Security: Payment Verification', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        req = {
+            user: { _id: 'userid' },
+            body: {
+                shippingInfo: {},
+                orderItems: [{ product: 'productid', quantity: 1, price: 1000 }],
+                paymentInfo: {
+                    id: 'pi_fake',
+                    status: 'succeeded'
+                },
+                itemsPrice: 1000,
+                taxPrice: 180,
+                shippingPrice: 200,
+                totalPrice: 1380
+            }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        next = jest.fn();
+
+        Product.find.mockResolvedValue([{
+            _id: 'productid',
+            price: 1000
+        }]);
+
+        Order.create.mockResolvedValue({ _id: 'orderid' });
+        // Reset findOne to ensure no leakage between tests
+        if (Order.findOne && Order.findOne.mockReset) Order.findOne.mockReset();
+    });
+
+    it('should REJECT order creation when actual payment status is invalid', async () => {
+        // Mock Stripe to return an invalid payment status
+        mockRetrieve.mockResolvedValue({
+            id: 'pi_fake',
+            status: 'requires_payment_method', // Invalid status
+            amount: 138000
+        });
+
+        await orderController.newOrder(req, res, next);
+
+        // Expectation: ErrorHandler called
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].message).toMatch(/Payment not verified/);
+        expect(Order.create).not.toHaveBeenCalled();
+        expect(mockRetrieve).toHaveBeenCalledWith('pi_fake');
+    });
+
+    it('should REJECT order creation when payment amount mismatches', async () => {
+        // Mock Stripe to return valid status but wrong amount
+        mockRetrieve.mockResolvedValue({
+            id: 'pi_fake',
+            status: 'succeeded',
+            amount: 100000 // Mismatch (should be 138000)
+        });
+
+        await orderController.newOrder(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].message).toMatch(/Payment amount mismatch/);
+        expect(Order.create).not.toHaveBeenCalled();
+    });
+
+    it('should REJECT order creation when payment status in body mismatches Stripe status', async () => {
+         req.body.paymentInfo.status = 'failed';
+
+         mockRetrieve.mockResolvedValue({
+            id: 'pi_fake',
+            status: 'succeeded',
+            amount: 138000
+        });
+
+        await orderController.newOrder(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].message).toMatch(/Payment status mismatch/);
+        expect(Order.create).not.toHaveBeenCalled();
+    });
+
+    it('should CREATE order when payment is valid and verified', async () => {
+        // Mock Stripe to return valid payment
+        mockRetrieve.mockResolvedValue({
+            id: 'pi_fake',
+            status: 'succeeded',
+            amount: 138000
+        });
+
+        await orderController.newOrder(req, res, next);
+
+        expect(Order.create).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            success: true
+        }));
+    });
+
+    it('should REJECT order creation when payment ID is already used (Replay Attack)', async () => {
+        // Mock Stripe to return valid payment
+        mockRetrieve.mockResolvedValue({
+            id: 'pi_fake',
+            status: 'succeeded',
+            amount: 138000
+        });
+
+        // Mock Order.findOne to find an existing order with the same payment ID
+        // Note: Order model is mocked, so findOne is a jest.fn()
+        // We simulate finding a document
+        Order.findOne.mockResolvedValue({ _id: 'existing_order_id' });
+
+        await orderController.newOrder(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].message).toMatch(/Payment already used/);
+        expect(Order.create).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Fixed a critical vulnerability where orders could be created without verifying the payment amount and status with the payment provider (Stripe). The fix includes:
  - Validating the payment status with Stripe.
  - Verifying the payment amount matches the order total.
  - Preventing replay attacks by checking for duplicate payment IDs.
  - Adding comprehensive tests to cover these scenarios.

---
*PR created automatically by Jules for task [10687380304858405234](https://jules.google.com/task/10687380304858405234) started by @parilsanghvi*