### PR TITLE
🔒 Security: Reduce request body limit to prevent DoS

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -17,10 +17,10 @@ app.use(compression());
 app.set('query parser', 'extended');
 
 // parsing object to json
-app.use(express.json({ limit: "50mb" }));
+app.use(express.json({ limit: "1mb" }));
 app.use(cookieParser())
 app.use(express.urlencoded({
-  limit: "50mb",
+  limit: "1mb",
   extended: true
 }))
 

--- a/backend/tests/security_payload_limit.test.js
+++ b/backend/tests/security_payload_limit.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('Security Payload Limit Test', () => {
+    // We use a non-existent route to avoid hitting controller logic / database.
+    // Express middleware (body-parser) runs before routing.
+    // If the payload is too large, it should return 413 immediately.
+    // If the payload is accepted, it should reach the router and return 404.
+
+    it('should reject a JSON payload larger than 1MB with 413 Payload Too Large', async () => {
+        // Create a large payload (slightly larger than 1MB)
+        const largePayload = {
+            data: 'a'.repeat(1.1 * 1024 * 1024) // ~1.1MB
+        };
+
+        const res = await request(app)
+            .post('/api/v1/nonexistent_route_for_test')
+            .send(largePayload)
+            .set('Content-Type', 'application/json');
+
+        // Current behavior (Vulnerable): Returns 404 (Body parsed, route not found)
+        // Fixed behavior (Secure): Returns 413 (Body too large)
+        expect(res.status).toBe(413);
+    });
+
+    it('should accept a small JSON payload', async () => {
+        const smallPayload = {
+            data: "small"
+        };
+
+        const res = await request(app)
+            .post('/api/v1/nonexistent_route_for_test')
+            .send(smallPayload)
+            .set('Content-Type', 'application/json');
+
+        // Should NOT be 413. Should be 404.
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability by reducing the maximum request body size for JSON and URL-encoded data from 50MB to 1MB.

### 🎯 What
- Modified `backend/app.js` to set `limit: "1mb"` for `express.json()` and `express.urlencoded()`.
- Added a new test file `backend/tests/security_payload_limit.test.js` to verify the fix.

### ⚠️ Risk
- **DoS Attack:** The previous 50MB limit allowed attackers to send large JSON payloads, potentially exhausting server memory and causing a crash or unresponsiveness.

### 🛡️ Solution
- **Reduced Limit:** 1MB is sufficient for standard API operations (metadata, text fields).
- **Multipart Support:** Confirmed that file uploads (avatars, product images) use `multipart/form-data` handled by `multer`, which bypasses `express.json` and `express.urlencoded`. Thus, legitimate large file uploads are preserved.
- **Verification:** The new test sends a ~1.1MB JSON payload and asserts a 413 "Payload Too Large" response. Existing tests confirm no regressions.

---
*PR created automatically by Jules for task [5223753292520711468](https://jules.google.com/task/5223753292520711468) started by @parilsanghvi*