### PR TITLE
🔒 Fix Insecure CORS Configuration

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -27,8 +27,22 @@ app.use(express.urlencoded({
 const cors = require('cors');
 const mongoSanitize = require('./middleware/mongoSanitize');
 
+const allowedOrigins = [
+  ...(process.env.FRONTEND_URL ? process.env.FRONTEND_URL.split(',') : []),
+  'http://localhost:3000',
+].filter(Boolean);
+
 app.use(cors({
-  origin: true,
+  origin: (origin, callback) => {
+    // Allow requests with no origin (like mobile apps or curl requests)
+    if (!origin) return callback(null, true);
+
+    if (allowedOrigins.indexOf(origin) !== -1) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   credentials: true
 }));
 

--- a/backend/tests/security_cors.test.js
+++ b/backend/tests/security_cors.test.js
@@ -1,0 +1,38 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('CORS Security', () => {
+    it('should NOT allow unauthorized origins (http://evil.com)', async () => {
+        const res = await request(app)
+            .get('/api/v1/non-existent-route')
+            .set('Origin', 'http://evil.com');
+
+        // Should return 500 because the CORS middleware calls next(err)
+        // And the error middleware returns 500
+        expect(res.status).toBe(500);
+        expect(res.body.message).toBe('Not allowed by CORS');
+        // Access-Control-Allow-Origin should NOT be present (or at least not evil.com)
+        // Actually, if it errors, no CORS headers are set usually.
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('should allow localhost:3000', async () => {
+        const res = await request(app)
+            .get('/api/v1/non-existent-route')
+            .set('Origin', 'http://localhost:3000');
+
+        // Should NOT return 500. It might return 404 because route doesn't exist, but that's fine.
+        expect(res.status).not.toBe(500);
+
+        expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3000');
+        expect(res.headers['access-control-allow-credentials']).toBe('true');
+    });
+
+    it('should allow requests with no origin (e.g. server-to-server)', async () => {
+        const res = await request(app)
+            .get('/api/v1/non-existent-route');
+            // No Origin header set
+
+        expect(res.status).not.toBe(500);
+    });
+});


### PR DESCRIPTION
This PR addresses a security vulnerability where `origin: true` combined with `credentials: true` in the CORS configuration allowed any website to make credentialed requests to the backend (Reflected Origin).

### Changes:
- Modified `backend/app.js` to use a function-based `origin` check in `cors` middleware.
- The check validates the `Origin` header against a whitelist.
- The whitelist includes:
    - `process.env.FRONTEND_URL` (split by comma if multiple)
    - `http://localhost:3000` (default for local development)
- Requests with no `Origin` header (e.g., server-to-server, mobile apps) are allowed.
- Requests with unauthorized `Origin` headers are rejected with a "Not allowed by CORS" error (resulting in 500 status).

### Verification:
- Added `backend/tests/security_cors.test.js` which confirms:
    - `Origin: http://evil.com` is rejected (500).
    - `Origin: http://localhost:3000` is allowed.
    - Requests without Origin are allowed.
- Ran existing integration tests (`admin.test.js`) to ensure no regressions in normal API usage.

---
*PR created automatically by Jules for task [10208832773652547587](https://jules.google.com/task/10208832773652547587) started by @parilsanghvi*