### PR TITLE
🔒 Security Fix: Limit Avatar Upload Size to 3MB

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -6,6 +6,8 @@ const sendEmail = require("../utlis/sendEmail")
 const crypto = require("crypto")
 const cloudinary = require("cloudinary")
 
+const MAX_AVATAR_SIZE = 3 * 1024 * 1024; // 3MB base64 string length
+
 // register a User
 exports.registerUser = catchAsyncErrors(async (req, res, next) => {
 
@@ -16,6 +18,9 @@ exports.registerUser = catchAsyncErrors(async (req, res, next) => {
     } = req.body;
     if (!req.body.avatar) {
         return next(new ErrorHandler("Please upload avatar", 401))
+    }
+    if (typeof req.body.avatar === "string" && req.body.avatar.length > MAX_AVATAR_SIZE) {
+        return next(new ErrorHandler("Avatar image size too large", 400));
     }
     const myCloud = await cloudinary.v2.uploader.upload(req.body.avatar, {
         folder: "avatars",
@@ -162,6 +167,9 @@ exports.updateProfile = catchAsyncErrors(async (req, res, next) => {
     if (req.body.avatar !== "") {
         if (!req.body.avatar || req.body.avatar === "undefined") {
             return next(new ErrorHandler("Please upload a new avatar", 401))
+        }
+        if (typeof req.body.avatar === "string" && req.body.avatar.length > MAX_AVATAR_SIZE) {
+            return next(new ErrorHandler("Avatar image size too large", 400));
         }
         // Optimized: Use req.user.avatar directly instead of redundant DB call
         const imageId = req.user.avatar.public_id

--- a/backend/tests/security_avatar_upload_size.test.js
+++ b/backend/tests/security_avatar_upload_size.test.js
@@ -1,0 +1,133 @@
+const request = require("supertest");
+const app = require("../app");
+const cloudinary = require("cloudinary");
+const User = require("../models/userModel");
+
+// Mock cloudinary
+jest.mock("cloudinary", () => ({
+    v2: {
+        uploader: {
+            upload: jest.fn().mockImplementation((file, options) => {
+                return Promise.resolve({
+                    public_id: "test_public_id",
+                    secure_url: "https://res.cloudinary.com/test/image/upload/v1234567890/avatars/test_public_id.jpg"
+                });
+            }),
+            destroy: jest.fn().mockResolvedValue({ result: "ok" })
+        },
+        config: jest.fn()
+    }
+}));
+
+// Helper to create mock user
+const getMockUser = () => ({
+    _id: "test_user_id",
+    name: "Test User",
+    email: "test@example.com",
+    avatar: { public_id: "old_id", url: "old_url" },
+    getJWTToken: jest.fn().mockReturnValue("test_token"),
+    comparePassword: jest.fn().mockResolvedValue(true),
+    save: jest.fn().mockResolvedValue(true),
+});
+
+// Mock User model
+jest.mock("../models/userModel", () => {
+    const mockUser = {
+        _id: "test_user_id",
+        name: "Test User",
+        email: "test@example.com",
+        avatar: { public_id: "old_id", url: "old_url" },
+        getJWTToken: jest.fn().mockReturnValue("test_token"),
+        comparePassword: jest.fn().mockResolvedValue(true),
+        save: jest.fn().mockResolvedValue(true),
+    };
+    return {
+        create: jest.fn().mockResolvedValue(mockUser),
+        findOne: jest.fn().mockReturnValue({
+            select: jest.fn().mockResolvedValue(mockUser),
+        }),
+        findById: jest.fn().mockReturnValue({
+            select: jest.fn().mockResolvedValue(mockUser),
+        }),
+        findByIdAndUpdate: jest.fn().mockResolvedValue(mockUser),
+    };
+});
+
+// Mock Auth Middleware
+jest.mock("../middleware/auth", () => {
+    const mockUser = {
+        _id: "test_user_id",
+        name: "Test User",
+        email: "test@example.com",
+        avatar: { public_id: "old_id", url: "old_url" },
+        getJWTToken: jest.fn().mockReturnValue("test_token"),
+        comparePassword: jest.fn().mockResolvedValue(true),
+        save: jest.fn().mockResolvedValue(true),
+    };
+    return {
+        isAuthenticatedUser: (req, res, next) => {
+            req.user = mockUser;
+            next();
+        },
+        authorizedRoles: (...roles) => (req, res, next) => {
+            next();
+        }
+    };
+});
+
+describe("Security: Avatar Upload Size Limit", () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("should REJECT avatar upload exceeding size limit during REGISTRATION", async () => {
+        // Create a large string (approx 5MB)
+        const largeAvatar = "data:image/jpeg;base64," + "a".repeat(5 * 1024 * 1024);
+
+        const response = await request(app)
+            .post("/api/v1/register")
+            .send({
+                name: "Test User",
+                email: "test_large_avatar@example.com",
+                password: "password123",
+                avatar: largeAvatar
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toMatch(/Avatar.*large/i);
+    });
+
+    test("should REJECT avatar upload exceeding size limit during PROFILE UPDATE", async () => {
+        // Create a large string (approx 5MB)
+        const largeAvatar = "data:image/jpeg;base64," + "a".repeat(5 * 1024 * 1024);
+
+        const response = await request(app)
+            .put("/api/v1/me/update")
+            .send({
+                name: "Updated Name",
+                email: "updated@example.com",
+                avatar: largeAvatar
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toMatch(/Avatar.*large/i);
+    });
+
+    test("should ACCEPT avatar upload within size limit", async () => {
+        // Create a small string (approx 1KB)
+        const smallAvatar = "data:image/jpeg;base64," + "a".repeat(1024);
+
+        const response = await request(app)
+            .post("/api/v1/register")
+            .send({
+                name: "Test User",
+                email: "test_small_avatar@example.com",
+                password: "password123",
+                avatar: smallAvatar
+            });
+
+        expect(response.status).toBe(201);
+        expect(response.body.success).toBe(true);
+    });
+});


### PR DESCRIPTION
Implemented a size limit (3MB) for avatar uploads in `userController.js` to prevent Denial of Service (DoS) attacks via large base64 strings. Added validation logic to `registerUser` and `updateProfile` endpoints. Verified the fix with a new test suite covering both endpoints and ensuring legitimate uploads still work. Addressed code review feedback by adding type checks and reverting accidental lockfile changes.

---
*PR created automatically by Jules for task [2249378314404420094](https://jules.google.com/task/2249378314404420094) started by @parilsanghvi*