### PR TITLE
Refactor order constants to backend/config/constants.js

### DIFF
--- a/backend/config/constants.js
+++ b/backend/config/constants.js
@@ -1,0 +1,10 @@
+// Business logic constants
+
+// Tax rate as a decimal (e.g., 0.18 = 18%)
+exports.TAX_RATE = 0.18;
+
+// Shipping threshold above which shipping is free
+exports.SHIPPING_THRESHOLD = 1000;
+
+// Standard shipping fee if below threshold
+exports.SHIPPING_FEE = 200;

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -4,6 +4,7 @@ const Product = require("../models/productModel");
 const ErrorHandler = require("../utlis/errorhandler");
 const catchAsyncErrors = require("../middleware/catchAsyncErrors");
 const Apifeatures = require("../utlis/apifeatures");
+const { TAX_RATE, SHIPPING_THRESHOLD, SHIPPING_FEE } = require("../config/constants");
 
 // create new order
 exports.newOrder = catchAsyncErrors(async (req, res, next) => {
@@ -38,8 +39,8 @@ exports.newOrder = catchAsyncErrors(async (req, res, next) => {
     // Security Fix: Validate all price components to prevent tampering
     // Calculate expected tax (18%) and shipping (Free over 1000, else 200)
     // Note: This logic duplicates frontend logic and should ideally be centralized
-    const calculatedTaxPrice = calculatedItemsPrice * 0.18;
-    const calculatedShippingPrice = calculatedItemsPrice > 1000 ? 0 : 200;
+    const calculatedTaxPrice = calculatedItemsPrice * TAX_RATE;
+    const calculatedShippingPrice = calculatedItemsPrice > SHIPPING_THRESHOLD ? 0 : SHIPPING_FEE;
     const calculatedTotalPrice = calculatedItemsPrice + calculatedTaxPrice + calculatedShippingPrice;
 
     if (isNaN(taxPrice) || Math.abs(Number(taxPrice) - calculatedTaxPrice) > 0.01) {


### PR DESCRIPTION
Extracted `TAX_RATE`, `SHIPPING_THRESHOLD`, and `SHIPPING_FEE` to `backend/config/constants.js`.
Updated `backend/controllers/orderController.js` to use these constants.
Verified that `backend/tests/security_price_tampering.test.js`, `backend/tests/security_total_price_tampering.test.js`, and `backend/tests/integration/order.test.js` still pass.

---
*PR created automatically by Jules for task [384277739507569655](https://jules.google.com/task/384277739507569655) started by @parilsanghvi*