### PR TITLE
🧹 Extract hardcoded API path to config file

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import axios from "axios";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import NotFound from "./component/layout/Not Found/NotFound";
+import { API_BASE_URL } from "./config";
 
 // Lazy Loaded Components
 const Profile = lazy(() => import("./component/User/Profile"));
@@ -51,7 +52,7 @@ function App() {
 
   async function getStripeApiKey() {
     try {
-      const { data } = await axios.get("/api/v1/stripeapikey");
+      const { data } = await axios.get(`${API_BASE_URL}/stripeapikey`);
       setStripeApiKey(data.stripeApiKey);
     } catch (error) {
       console.log("Stripe API key not found or backend unreachable");

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "/api/v1";


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded API path `/api/v1/stripeapikey` in `frontend/src/App.jsx` to use a constant `API_BASE_URL` defined in `frontend/src/config.js`.

💡 **Why:** Hardcoded API paths make it difficult to change API versions or structures. Extracting them to a configuration file improves maintainability and allows for easier updates in the future.

✅ **Verification:**
- Created `frontend/src/config.js` with `export const API_BASE_URL = "/api/v1";`.
- Updated `frontend/src/App.jsx` to import and use `API_BASE_URL`.
- Ran `npm test` in the `frontend` directory, and all 249 tests passed.
- Verified the code changes by reading the modified files.

✨ **Result:** The `getStripeApiKey` function in `App.jsx` now uses the centralized API configuration, making the codebase cleaner and more maintainable.


---
*PR created automatically by Jules for task [15107706476621949938](https://jules.google.com/task/15107706476621949938) started by @parilsanghvi*