### PR TITLE
🛡️ Sentinel: [Enhancement] Add security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 1. In payment processing logic, receive the list of items (IDs and quantities) instead of the total amount.
 2. Fetch the product details from the database and calculate the total amount server-side.
 3. Use this server-side calculated amount for payment gateway interactions.
+
+## 2025-02-20 - [Enhancement] Added Security Headers
+**Vulnerability:** Missing standard HTTP security headers (HSTS, X-Frame-Options, X-Content-Type-Options, etc.).
+**Learning:** Even with a decent security baseline (rate limiting, input sanitization), basic headers are often overlooked. Manual implementation is simple and avoids dependencies.
+**Prevention:** Use a middleware to set these headers globally.

--- a/backend/app.js
+++ b/backend/app.js
@@ -7,10 +7,16 @@ app.set('trust proxy', 1);
 
 const cookieParser = require("cookie-parser");
 const errorMidddleware = require('./middleware/error');
+const securityHeaders = require('./middleware/securityHeaders');
 const path = require("path")
 
 // Enable compression
 app.use(compression());
+
+// Set security headers
+app.use(securityHeaders);
+app.disable('x-powered-by');
+
 // config
 
 // Enable extended query parser for bracket notation (e.g., ratings[gte]=1 -> {ratings: {gte: 1}})

--- a/backend/middleware/securityHeaders.js
+++ b/backend/middleware/securityHeaders.js
@@ -1,0 +1,24 @@
+// Middleware to set security headers for defense in depth
+
+const securityHeaders = (req, res, next) => {
+    // Prevent MIME sniffing
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    // Prevent clickjacking
+    // Use SAMEORIGIN to allow framing by same site if needed (e.g. iframes within app)
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+
+    // HTTP Strict Transport Security (HSTS) - 1 year
+    // Only apply in production or if secure (HTTPS)
+    // This tells browsers to ONLY use HTTPS for future requests
+    if (process.env.NODE_ENV === 'PRODUCTION' || req.secure || req.headers['x-forwarded-proto'] === 'https') {
+        res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+
+    // Referrer Policy - control how much referrer information is sent
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+    next();
+};
+
+module.exports = securityHeaders;

--- a/backend/tests/security_headers.test.js
+++ b/backend/tests/security_headers.test.js
@@ -1,0 +1,84 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+// Mock dependencies to avoid side effects
+jest.mock('../utlis/sendEmail', () => jest.fn());
+jest.mock('cloudinary', () => ({
+    v2: {
+        config: jest.fn(),
+        uploader: {
+            upload: jest.fn(),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+let app;
+let mongoServer;
+
+describe('Security Headers Middleware', () => {
+    // Increase timeout for MongoMemoryServer startup
+    jest.setTimeout(60000);
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+        process.env.DB_URI = uri;
+
+        if (mongoose.connection.readyState === 0) {
+            await mongoose.connect(uri);
+        }
+
+        // Import app after setting DB_URI
+        app = require('../app');
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    it('should set critical security headers', async () => {
+        const res = await request(app).get('/api/v1/products'); // Use a valid route
+
+        expect(res.headers['x-content-type-options']).toBe('nosniff');
+        expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+        expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+        expect(res.headers['x-powered-by']).toBeUndefined();
+    });
+
+    it('should set HSTS header in PRODUCTION environment', async () => {
+        const originalEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'PRODUCTION';
+
+        const res = await request(app).get('/api/v1/products');
+
+        expect(res.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+
+        // Restore environment
+        process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should set HSTS header if request is secure (HTTPS)', async () => {
+        // Supertest doesn't easily simulate HTTPS physically, but we can mock req.secure
+        // OR we can test X-Forwarded-Proto which our middleware supports
+
+        const res = await request(app)
+            .get('/api/v1/products')
+            .set('X-Forwarded-Proto', 'https');
+
+        expect(res.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+    });
+
+    it('should NOT set HSTS header in development/test environment without HTTPS', async () => {
+        const originalEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'development';
+
+        const res = await request(app).get('/api/v1/products');
+
+        expect(res.headers['strict-transport-security']).toBeUndefined();
+
+        process.env.NODE_ENV = originalEnv;
+    });
+});


### PR DESCRIPTION
This PR adds a custom middleware `securityHeaders` to set standard HTTP security headers for defense in depth. It also disables the `X-Powered-By` header to reduce information leakage. A new test suite `backend/tests/security_headers.test.js` verifies the implementation.

---
*PR created automatically by Jules for task [11646166241122377170](https://jules.google.com/task/11646166241122377170) started by @parilsanghvi*