### PR TITLE
🎨 Palette: Add auto-focus to product search input

### DIFF
--- a/frontend/src/__tests__/components/Search.test.jsx
+++ b/frontend/src/__tests__/components/Search.test.jsx
@@ -52,4 +52,10 @@ describe('Search', () => {
         fireEvent.submit(input.closest('form'));
         expect(mockNavigate).toHaveBeenCalledWith('/products');
     });
+
+    it('should have focus on mount', () => {
+        render(<Search />);
+        const input = screen.getByLabelText('Search products');
+        expect(input).toHaveFocus();
+    });
 });

--- a/frontend/src/component/Product/Search.jsx
+++ b/frontend/src/component/Product/Search.jsx
@@ -23,6 +23,7 @@ const Search = () => {
                     type="text"
                     placeholder="Search products..."
                     aria-label="Search products" // Added for accessibility
+                    autoFocus
                     onChange={(e) => setKeyword(e.target.value)}
                 />
                 <input type="submit" value="Search" className="primary-btn" style={{ width: 'auto', padding: '0 2rem', height: '60px' }} />

--- a/frontend_output.log
+++ b/frontend_output.log
@@ -1,0 +1,25 @@
+
+> frontend@0.1.0 start
+> vite
+
+
+  VITE v7.3.1  ready in 333 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: use --host to expose
+2:28:19 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:28:19 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:28:46 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:28:46 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)


### PR DESCRIPTION
💡 **What:** Added the `autoFocus` attribute to the search input in `Search.jsx`.
🎯 **Why:** Users navigating to the dedicated search page expect to type immediately. This reduces friction and clicks.
📸 **Before/After:** The input now automatically receives focus on page load.
♿ **Accessibility:** This is a standard pattern for dedicated search pages. The input already has an accessible name via `aria-label`.

---
*PR created automatically by Jules for task [10129850225407642339](https://jules.google.com/task/10129850225407642339) started by @parilsanghvi*