### PR TITLE
🛡️ Sentinel: Fix insecure cookie configuration in production

### DIFF
--- a/backend/tests/jwtToken.test.js
+++ b/backend/tests/jwtToken.test.js
@@ -37,6 +37,17 @@ describe('JWT Token Utility', () => {
         expect(options).toHaveProperty('sameSite', 'strict'); // Fixed security gap
     });
 
+    it('should set secure cookie in "production" (lowercase)', () => {
+        process.env.NODE_ENV = 'production';
+
+        sendToken(user, 200, res);
+
+        const cookieCall = res.cookie.mock.calls[0];
+        const options = cookieCall[2];
+
+        expect(options).toHaveProperty('secure', true);
+    });
+
     it('should NOT set secure cookie in DEVELOPMENT', () => {
         process.env.NODE_ENV = 'DEVELOPMENT';
 

--- a/backend/utlis/jwtToken.js
+++ b/backend/utlis/jwtToken.js
@@ -7,7 +7,7 @@ const sendToken = (user, statusCode, res) => {
             Date.now() + process.env.COOKIE_EXPIRE * 24 * 60 * 60 * 1000
         ),
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'PRODUCTION',
+        secure: process.env.NODE_ENV === 'PRODUCTION' || process.env.NODE_ENV === 'production',
         sameSite: 'strict',
     }
     res.status(statusCode).cookie("token",token,options).json({


### PR DESCRIPTION
**Vulnerability:** Insecure Cookie Configuration
**Location:** `backend/utlis/jwtToken.js`
**Description:** The `secure` flag for the authentication cookie was only set if `NODE_ENV` was strictly equal to `'PRODUCTION'`. In many environments (including standard Node.js practices), `NODE_ENV` is set to `'production'`. This meant the cookie would be sent over insecure HTTP connections in production if the environment variable was lowercase, exposing the session token to interception.
**Fix:** Updated the check to be case-insensitive or check for both 'production' and 'PRODUCTION'.
**Verification:** Added a regression test in `backend/tests/jwtToken.test.js` and verified all backend tests pass.

---
*PR created automatically by Jules for task [6039914378143694428](https://jules.google.com/task/6039914378143694428) started by @parilsanghvi*