### PR TITLE
🎨 Palette: Improve Login/Register Loading State

### DIFF
--- a/frontend/frontend.log
+++ b/frontend/frontend.log
@@ -1,0 +1,38 @@
+
+> frontend@0.1.0 start /app/frontend
+> vite
+
+
+  VITE v7.3.1  ready in 414 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: use --host to expose
+2:23:32 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:23:32 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:23:51 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:23:51 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:24:55 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:24:55 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:24:56 PM [vite] http proxy error: /api/v1/login
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+ ELIFECYCLE  Command failed.

--- a/frontend/src/__tests__/LoginSignup_Loading.test.jsx
+++ b/frontend/src/__tests__/LoginSignup_Loading.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import LoginSignup from '../component/User/LoginSignup';
+
+// Mock Redux
+vi.mock('react-redux', () => ({
+    ...vi.importActual('react-redux'),
+    useDispatch: () => vi.fn(),
+    useSelector: (selector) => selector({
+        user: {
+            loading: true, // Force loading state
+            isAuthenticated: false,
+            error: null
+        }
+    }),
+}));
+
+// Mock Notistack
+vi.mock('notistack', () => ({
+    useSnackbar: () => ({
+        enqueueSnackbar: vi.fn()
+    })
+}));
+
+// Mock Router
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+        useLocation: () => ({ pathname: '/login', search: '' }),
+    };
+});
+
+describe('LoginSignup Loading State', () => {
+    it('shows loading state and disables inputs', () => {
+        render(
+            <BrowserRouter>
+                <LoginSignup />
+            </BrowserRouter>
+        );
+
+        // Check for Login button text
+        const loginBtn = screen.getByRole('button', { name: /Logging In.../i });
+        expect(loginBtn).toBeInTheDocument();
+        expect(loginBtn).toBeDisabled();
+
+        // Check for Register button text (hidden because tab is inactive)
+        const registerBtn = screen.getByRole('button', { name: /Registering.../i, hidden: true });
+        expect(registerBtn).toBeInTheDocument();
+        expect(registerBtn).toBeDisabled();
+
+        // Check inputs are disabled
+        // Login inputs (visible)
+        expect(screen.getByLabelText('Login Email')).toBeDisabled();
+        expect(screen.getByLabelText('Login Password')).toBeDisabled();
+
+        // Register inputs (hidden)
+        expect(screen.getByLabelText('Name', { hidden: true })).toBeDisabled();
+        expect(screen.getByLabelText('Email', { hidden: true })).toBeDisabled();
+        expect(screen.getByLabelText('Password', { hidden: true })).toBeDisabled();
+        expect(screen.getByLabelText('Avatar Upload', { hidden: true })).toBeDisabled();
+
+        // Check tabs are disabled
+        expect(screen.getByRole('tab', { name: /Login/i })).toBeDisabled();
+        expect(screen.getByRole('tab', { name: /Register/i })).toBeDisabled();
+    });
+});

--- a/frontend/src/component/User/LoginSignup.jsx
+++ b/frontend/src/component/User/LoginSignup.jsx
@@ -1,6 +1,5 @@
 import React, { Fragment, useRef, useState, useEffect } from 'react'
 import "./LoginSignup.css"
-import Loader from "../layout/Loader"
 import { Link, useNavigate, useLocation } from 'react-router-dom'
 import MailOutlineIcon from "@mui/icons-material/MailOutline"
 import LockOpenIcon from "@mui/icons-material/LockOpen"
@@ -119,164 +118,169 @@ const LoginSignup = () => {
     }
     return (
         <Fragment>
-            {loading ? (<Loader />
-            ) : (
-                <Fragment>
-                    <div className='LoginSignUpContainer'>
-                        <div className='LoginSignUpBox'>
-                            <div>
-                                <div className='login_signUp_toggle' role="tablist">
-                                    <button
-                                        className="toggle-btn"
-                                        onClick={(e) => switchTabs(e, "login")}
-                                        role="tab"
-                                        aria-selected={activeTab === "login"}
-                                        aria-controls="login-panel"
-                                        id="login-tab"
-                                    >
-                                        Login
-                                    </button>
-                                    <button
-                                        className="toggle-btn"
-                                        onClick={(e) => switchTabs(e, "register")}
-                                        role="tab"
-                                        aria-selected={activeTab === "register"}
-                                        aria-controls="register-panel"
-                                        id="register-tab"
-                                    >
-                                        Register
-                                    </button>
-                                </div>
-                                <div className="slider-line" ref={switcherTab}></div>
-                            </div >
-                            {(error || localError) && (
-                                <div className="loginError">
-                                    <MdErrorOutline />
-                                    <span>{localError || (error === "Field value too long" ? "File is too large" : error)}</span>
-                                </div>
-                            )}
-                            <form
-                                className='loginForm'
-                                ref={loginTab}
-                                onSubmit={loginSubmit}
-                                role="tabpanel"
-                                id="login-panel"
-                                aria-labelledby="login-tab"
-                                aria-hidden={activeTab !== "login"}
+            <div className='LoginSignUpContainer'>
+                <div className='LoginSignUpBox'>
+                    <div>
+                        <div className='login_signUp_toggle' role="tablist">
+                            <button
+                                className="toggle-btn"
+                                onClick={(e) => switchTabs(e, "login")}
+                                role="tab"
+                                aria-selected={activeTab === "login"}
+                                aria-controls="login-panel"
+                                id="login-tab"
+                                disabled={loading}
                             >
-                                <div className='loginEmail'>
-                                    <MailOutlineIcon />
-                                    <input
-                                        type="email"
-                                        placeholder="Email"
-                                        aria-label="Login Email"
-                                        required
-                                        value={loginEmail}
-                                        onChange={(e) => {
-                                            setLoginEmail(e.target.value);
-                                            clearLocalAndGlobalErrors();
-                                        }}
-                                    />
-                                </div>
-                                <div className='loginPassword'>
-                                    <LockOpenIcon />
-                                    <input
-                                        type={showLoginPassword ? "text" : "password"}
-                                        placeholder="Password"
-                                        aria-label="Login Password"
-                                        required
-                                        value={loginPassword}
-                                        onChange={(e) => {
-                                            setLoginPassword(e.target.value);
-                                            clearLocalAndGlobalErrors();
-                                        }}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowLoginPassword(!showLoginPassword)}
-                                        className="password-toggle-btn"
-                                        aria-label={showLoginPassword ? "Hide password" : "Show password"}
-                                    >
-                                        {showLoginPassword ? <VisibilityOff /> : <Visibility />}
-                                    </button>
-                                </div>
-                                <Link to="/password/forgot">Forgot Password ?</Link>
-                                <input type="submit" value="Login" className='primary-btn' />
-                            </form>
-                            <form
-                                className='signUpForm'
-                                ref={registerTab}
-                                encType='multipart/form-data'
-                                onSubmit={registerSubmit}
-                                role="tabpanel"
-                                id="register-panel"
-                                aria-labelledby="register-tab"
-                                aria-hidden={activeTab !== "register"}
+                                Login
+                            </button>
+                            <button
+                                className="toggle-btn"
+                                onClick={(e) => switchTabs(e, "register")}
+                                role="tab"
+                                aria-selected={activeTab === "register"}
+                                aria-controls="register-panel"
+                                id="register-tab"
+                                disabled={loading}
                             >
-                                <div className='signUpName'>
-                                    <FaceIcon />
-                                    <input
-                                        type="text"
-                                        placeholder="Name"
-                                        aria-label="Name"
-                                        required
-                                        name="name"
-                                        value={name}
-                                        onChange={registerDataChange}
-                                    />
-                                </div>
-                                <div className='signUpEmail'>
-                                    <MailOutlineIcon />
-                                    <input
-                                        type="email"
-                                        placeholder="Email"
-                                        aria-label="Email"
-                                        required
-                                        name='email'
-                                        value={email}
-                                        onChange={registerDataChange}
-                                    />
-                                </div>
-                                <div className='signUpPassword'>
-                                    <LockOpenIcon />
-                                    <input
-                                        type={showRegisterPassword ? "text" : "password"}
-                                        placeholder="Password"
-                                        aria-label="Password"
-                                        required
-                                        name='password'
-                                        value={password}
-                                        onChange={registerDataChange}
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={() => setShowRegisterPassword(!showRegisterPassword)}
-                                        className="password-toggle-btn"
-                                        aria-label={showRegisterPassword ? "Hide password" : "Show password"}
-                                    >
-                                        {showRegisterPassword ? <VisibilityOff /> : <Visibility />}
-                                    </button>
-                                </div>
-                                <div id='registerImage'>
-                                    <img src={avatarPreview} alt="avatar preview" />
-                                    <input
-                                        type="file"
-                                        name='avatar'
-                                        accept='image/*'
-                                        aria-label="Avatar Upload"
-                                        onChange={registerDataChange}
-                                    />
-                                </div>
-                                <input
-                                    type="submit"
-                                    value="Register"
-                                    className='primary-btn'
-                                />
-                            </form>
-                        </div >
+                                Register
+                            </button>
+                        </div>
+                        <div className="slider-line" ref={switcherTab}></div>
                     </div >
-                </Fragment >
-            )}
+                    {(error || localError) && (
+                        <div className="loginError">
+                            <MdErrorOutline />
+                            <span>{localError || (error === "Field value too long" ? "File is too large" : error)}</span>
+                        </div>
+                    )}
+                    <form
+                        className='loginForm'
+                        ref={loginTab}
+                        onSubmit={loginSubmit}
+                        role="tabpanel"
+                        id="login-panel"
+                        aria-labelledby="login-tab"
+                        aria-hidden={activeTab !== "login"}
+                    >
+                        <div className='loginEmail'>
+                            <MailOutlineIcon />
+                            <input
+                                type="email"
+                                placeholder="Email"
+                                aria-label="Login Email"
+                                required
+                                value={loginEmail}
+                                disabled={loading}
+                                onChange={(e) => {
+                                    setLoginEmail(e.target.value);
+                                    clearLocalAndGlobalErrors();
+                                }}
+                            />
+                        </div>
+                        <div className='loginPassword'>
+                            <LockOpenIcon />
+                            <input
+                                type={showLoginPassword ? "text" : "password"}
+                                placeholder="Password"
+                                aria-label="Login Password"
+                                required
+                                value={loginPassword}
+                                disabled={loading}
+                                onChange={(e) => {
+                                    setLoginPassword(e.target.value);
+                                    clearLocalAndGlobalErrors();
+                                }}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowLoginPassword(!showLoginPassword)}
+                                className="password-toggle-btn"
+                                aria-label={showLoginPassword ? "Hide password" : "Show password"}
+                                disabled={loading}
+                            >
+                                {showLoginPassword ? <VisibilityOff /> : <Visibility />}
+                            </button>
+                        </div>
+                        <Link to="/password/forgot">Forgot Password ?</Link>
+                        <button type="submit" className='primary-btn' disabled={loading}>
+                            {loading ? "Logging In..." : "Login"}
+                        </button>
+                    </form>
+                    <form
+                        className='signUpForm'
+                        ref={registerTab}
+                        encType='multipart/form-data'
+                        onSubmit={registerSubmit}
+                        role="tabpanel"
+                        id="register-panel"
+                        aria-labelledby="register-tab"
+                        aria-hidden={activeTab !== "register"}
+                    >
+                        <div className='signUpName'>
+                            <FaceIcon />
+                            <input
+                                type="text"
+                                placeholder="Name"
+                                aria-label="Name"
+                                required
+                                name="name"
+                                value={name}
+                                disabled={loading}
+                                onChange={registerDataChange}
+                            />
+                        </div>
+                        <div className='signUpEmail'>
+                            <MailOutlineIcon />
+                            <input
+                                type="email"
+                                placeholder="Email"
+                                aria-label="Email"
+                                required
+                                name='email'
+                                value={email}
+                                disabled={loading}
+                                onChange={registerDataChange}
+                            />
+                        </div>
+                        <div className='signUpPassword'>
+                            <LockOpenIcon />
+                            <input
+                                type={showRegisterPassword ? "text" : "password"}
+                                placeholder="Password"
+                                aria-label="Password"
+                                required
+                                name='password'
+                                value={password}
+                                disabled={loading}
+                                onChange={registerDataChange}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowRegisterPassword(!showRegisterPassword)}
+                                className="password-toggle-btn"
+                                aria-label={showRegisterPassword ? "Hide password" : "Show password"}
+                                disabled={loading}
+                            >
+                                {showRegisterPassword ? <VisibilityOff /> : <Visibility />}
+                            </button>
+                        </div>
+                        <div id='registerImage'>
+                            <img src={avatarPreview} alt="avatar preview" />
+                            <input
+                                type="file"
+                                name='avatar'
+                                accept='image/*'
+                                aria-label="Avatar Upload"
+                                disabled={loading}
+                                onChange={registerDataChange}
+                            />
+                        </div>
+                        <button type="submit" className='primary-btn' disabled={loading}>
+                            {loading ? "Registering..." : "Register"}
+                        </button>
+                    </form>
+                </div >
+            </div >
         </Fragment >
     )
 }


### PR DESCRIPTION
💡 What: Replaced the full-page Loader component with inline loading states on the Login and Register forms.
🎯 Why: Prevents jarring layout shifts and context loss during authentication.
📸 Before/After: Validated via Playwright screenshot.
♿ Accessibility: Added disabled states to inputs and buttons during loading to prevent double submission and provide feedback.

---
*PR created automatically by Jules for task [15964697485995808374](https://jules.google.com/task/15964697485995808374) started by @parilsanghvi*