### PR TITLE
🎨 Palette: Add loading state to cart quantity buttons

### DIFF
--- a/frontend/frontend.log
+++ b/frontend/frontend.log
@@ -1,0 +1,52 @@
+
+> frontend@0.1.0 start /app/frontend
+> vite
+
+
+  VITE v7.3.1  ready in 396 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: use --host to expose
+2:18:14 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:18:14 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:19:02 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:19:02 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:19:25 PM [vite] (client) hmr update /src/component/Cart/Cart.jsx
+2:19:35 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:19:35 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:19:52 PM [vite] (client) hmr update /src/component/Cart/Cart.jsx
+2:20:01 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:20:01 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:20:17 PM [vite] (client) hmr update /src/component/Cart/Cart.jsx
+2:20:27 PM [vite] http proxy error: /api/v1/me
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+2:20:27 PM [vite] http proxy error: /api/v1/stripeapikey
+AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)

--- a/frontend/src/__tests__/components/Cart.test.jsx
+++ b/frontend/src/__tests__/components/Cart.test.jsx
@@ -18,6 +18,7 @@ vi.mock('@mui/icons-material/RemoveShoppingCart', () => ({
 vi.mock('@mui/material', () => ({
     Typography: ({ children, ...props }) => <span {...props}>{children}</span>,
     Tooltip: ({ children }) => <>{children}</>,
+    CircularProgress: () => <div data-testid="circular-progress" />,
 }));
 
 // Mock CartItemCard

--- a/frontend/src/__tests__/components/Cart_UX.test.jsx
+++ b/frontend/src/__tests__/components/Cart_UX.test.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Cart from '../../component/Cart/Cart';
+
+// Mock react-router
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+    ...vi.importActual('react-router-dom'),
+    useNavigate: () => mockNavigate,
+    Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+// Mock MUI
+vi.mock('@mui/icons-material/RemoveShoppingCart', () => ({
+    default: () => <span data-testid="empty-cart-icon" />,
+}));
+vi.mock('@mui/material', () => ({
+    Typography: ({ children, ...props }) => <span {...props}>{children}</span>,
+    Tooltip: ({ children }) => <>{children}</>,
+    CircularProgress: (props) => <div role="progressbar" {...props} />, // Mock CircularProgress
+}));
+
+// Mock CartItemCard
+vi.mock('../../component/Cart/CartItemCard', () => ({
+    default: ({ item }) => <div data-testid={`cart-item-${item.product}`}>{item.name}</div>,
+}));
+
+// Mock useDispatch to control promise resolution
+const mockDispatchFn = vi.fn();
+let mockResolve;
+
+vi.mock('react-redux', () => ({
+    useSelector: (selector) => selector({
+        cart: {
+            cartItems: [
+                { product: 'p1', name: 'Item 1', price: 100, quantity: 2, stock: 5, image: 'img.jpg' },
+            ],
+            shippingInfo: {}
+        }
+    }),
+    useDispatch: () => mockDispatchFn,
+}));
+
+describe('Cart UX', () => {
+    beforeEach(() => {
+        mockDispatchFn.mockReset();
+        mockDispatchFn.mockImplementation(() => new Promise((resolve) => {
+            mockResolve = resolve;
+        }));
+        mockNavigate.mockClear();
+    });
+
+    it('shows loading spinner on "increase" button when clicked', async () => {
+        render(<Cart />);
+
+        const increaseBtn = screen.getByLabelText('Increase quantity');
+        const decreaseBtn = screen.getByLabelText('Decrease quantity');
+
+        // Click increase button
+        fireEvent.click(increaseBtn);
+
+        // Check if loading spinner appears inside increase button and buttons are disabled
+        await waitFor(() => {
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+            expect(screen.getByLabelText('Increase quantity')).toBeDisabled();
+            expect(screen.getByLabelText('Decrease quantity')).toBeDisabled();
+        });
+
+        // Resolve the dispatch promise
+        mockResolve();
+
+        // Wait for loading state to clear
+        await waitFor(() => {
+            expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+        });
+
+        // Buttons should be enabled again
+        expect(increaseBtn).not.toBeDisabled();
+        expect(decreaseBtn).not.toBeDisabled();
+    });
+
+    it('shows loading spinner on "decrease" button when clicked', async () => {
+        render(<Cart />);
+
+        const increaseBtn = screen.getByLabelText('Increase quantity');
+        const decreaseBtn = screen.getByLabelText('Decrease quantity');
+
+        // Click decrease button
+        fireEvent.click(decreaseBtn);
+
+        // Check spinner inside decrease button and buttons are disabled
+        await waitFor(() => {
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+            expect(screen.getByLabelText('Increase quantity')).toBeDisabled();
+            expect(screen.getByLabelText('Decrease quantity')).toBeDisabled();
+        });
+
+        // Resolve dispatch
+        mockResolve();
+
+        await waitFor(() => {
+            expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/component/Cart/Cart.jsx
+++ b/frontend/src/component/Cart/Cart.jsx
@@ -3,30 +3,50 @@ import "./Cart.css";
 import CartItemCard from "./CartItemCard";
 import { useSelector, useDispatch } from "react-redux";
 import { addItemsToCart, removeItemsFromCart } from "../../features/cartSlice";
-import { Typography, Tooltip } from "@mui/material";
+import { Typography, Tooltip, CircularProgress } from "@mui/material";
 import RemoveShoppingCartIcon from "@mui/icons-material/RemoveShoppingCart";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
+import { useState } from "react";
 
 const Cart = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { cartItems } = useSelector((state) => state.cart);
+  const [updatingItems, setUpdatingItems] = useState({});
 
-  const increaseQuantity = (id, quantity, stock) => {
+  const increaseQuantity = async (id, quantity, stock) => {
     const newQty = quantity + 1;
     if (stock <= quantity) {
       return;
     }
-    dispatch(addItemsToCart({ id, quantity: newQty }));
+    setUpdatingItems((prev) => ({ ...prev, [id]: "increase" }));
+    try {
+      await dispatch(addItemsToCart({ id, quantity: newQty }));
+    } finally {
+      setUpdatingItems((prev) => {
+        const newState = { ...prev };
+        delete newState[id];
+        return newState;
+      });
+    }
   };
 
-  const decreaseQuantity = (id, quantity) => {
+  const decreaseQuantity = async (id, quantity) => {
     const newQty = quantity - 1;
     if (1 >= quantity) {
       return;
     }
-    dispatch(addItemsToCart({ id, quantity: newQty }));
+    setUpdatingItems((prev) => ({ ...prev, [id]: "decrease" }));
+    try {
+      await dispatch(addItemsToCart({ id, quantity: newQty }));
+    } finally {
+      setUpdatingItems((prev) => {
+        const newState = { ...prev };
+        delete newState[id];
+        return newState;
+      });
+    }
   };
 
   const deleteCartItems = (id) => {
@@ -70,10 +90,15 @@ const Cart = () => {
                         onClick={() =>
                           decreaseQuantity(item.product, item.quantity)
                         }
-                        aria-disabled={item.quantity <= 1}
+                        disabled={!!updatingItems[item.product]}
+                        aria-disabled={item.quantity <= 1 || !!updatingItems[item.product]}
                         aria-label="Decrease quantity"
                       >
-                        -
+                        {updatingItems[item.product] === "decrease" ? (
+                          <CircularProgress size={20} sx={{ color: 'var(--color-primary)' }} />
+                        ) : (
+                          "-"
+                        )}
                       </button>
                     </Tooltip>
                     <input
@@ -81,6 +106,7 @@ const Cart = () => {
                       value={item.quantity}
                       readOnly
                       aria-label="Product quantity"
+                      aria-busy={!!updatingItems[item.product]}
                     />
                     <Tooltip title={item.stock <= item.quantity ? "Maximum stock reached" : ""}>
                       <button
@@ -91,10 +117,15 @@ const Cart = () => {
                             item.stock
                           )
                         }
-                        aria-disabled={item.stock <= item.quantity}
+                        disabled={!!updatingItems[item.product]}
+                        aria-disabled={item.stock <= item.quantity || !!updatingItems[item.product]}
                         aria-label="Increase quantity"
                       >
-                        +
+                        {updatingItems[item.product] === "increase" ? (
+                          <CircularProgress size={20} sx={{ color: 'var(--color-primary)' }} />
+                        ) : (
+                          "+"
+                        )}
                       </button>
                     </Tooltip>
                   </div>


### PR DESCRIPTION
💡 What: Added a loading spinner (CircularProgress) to the Cart quantity increase/decrease buttons.
🎯 Why: Users had no feedback when updating cart quantity, leading to potential confusion or multiple clicks.
♿ Accessibility: Added aria-busy and aria-disabled states. Used theme color for contrast against disabled button background.
📸 Validated with Playwright screenshot and unit tests.

---
*PR created automatically by Jules for task [314212129752151861](https://jules.google.com/task/314212129752151861) started by @parilsanghvi*