### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure cookie flag in production environment

### DIFF
--- a/backend/tests/jwtToken.test.js
+++ b/backend/tests/jwtToken.test.js
@@ -37,6 +37,18 @@ describe('JWT Token Utility', () => {
         expect(options).toHaveProperty('sameSite', 'strict'); // Fixed security gap
     });
 
+    it('should set secure cookie in production (lowercase)', () => {
+        process.env.NODE_ENV = 'production';
+
+        sendToken(user, 200, res);
+
+        const cookieCall = res.cookie.mock.calls[0];
+        const options = cookieCall[2];
+
+        expect(options).toHaveProperty('secure', true);
+        expect(options).toHaveProperty('sameSite', 'strict');
+    });
+
     it('should NOT set secure cookie in DEVELOPMENT', () => {
         process.env.NODE_ENV = 'DEVELOPMENT';
 

--- a/backend/utlis/jwtToken.js
+++ b/backend/utlis/jwtToken.js
@@ -7,7 +7,7 @@ const sendToken = (user, statusCode, res) => {
             Date.now() + process.env.COOKIE_EXPIRE * 24 * 60 * 60 * 1000
         ),
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'PRODUCTION',
+        secure: process.env.NODE_ENV === 'PRODUCTION' || process.env.NODE_ENV === 'production',
         sameSite: 'strict',
     }
     res.status(statusCode).cookie("token",token,options).json({


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Inconsistent Secure Cookie Handling. The `secure` flag for JWT cookies was only set if `NODE_ENV` was strictly `'PRODUCTION'`. Standard deployments using `NODE_ENV=production` (lowercase) would leave the cookie insecure (transmittable over HTTP), potentially exposing session tokens to network sniffing.
🎯 **Impact:** If deployed with lowercase `production` environment variable (which is standard), session cookies would lack the `Secure` attribute, making them vulnerable to interception if not behind a properly configured TLS proxy or if mixed content is allowed.
🔧 **Fix:** Updated `backend/utlis/jwtToken.js` to check for both `'PRODUCTION'` and `'production'`.
✅ **Verification:** Added a new test case in `backend/tests/jwtToken.test.js` that sets `process.env.NODE_ENV = 'production'` and asserts `secure: true`. Verified that the test failed before the fix and passed after. Ran full backend test suite to ensure no regressions.

---
*PR created automatically by Jules for task [4519073598352820927](https://jules.google.com/task/4519073598352820927) started by @parilsanghvi*