### PR TITLE
🎨 Palette: Add password visibility toggle to Update Password

### DIFF
--- a/frontend/src/__tests__/UpdatePassword_UX.test.jsx
+++ b/frontend/src/__tests__/UpdatePassword_UX.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import UpdatePassword from '../component/User/UpdatePassword';
+
+// Mock Redux
+const mockDispatch = vi.fn();
+vi.mock('react-redux', () => ({
+    ...vi.importActual('react-redux'),
+    useDispatch: () => mockDispatch,
+    useSelector: (selector) => selector({
+        user: {
+            loading: false,
+            isUpdated: false,
+            error: null
+        }
+    }),
+}));
+
+// Mock Notistack
+vi.mock('notistack', () => ({
+    useSnackbar: () => ({
+        enqueueSnackbar: vi.fn()
+    })
+}));
+
+// Mock Router
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+    };
+});
+
+// Mock MetaData to avoid Helmet context issues
+vi.mock('../component/layout/MetaData', () => ({
+    default: () => <div>MetaData</div>,
+}));
+
+describe('UpdatePassword Component UX', () => {
+    beforeEach(() => {
+        mockDispatch.mockClear();
+    });
+
+    it('toggles password visibility for old password', () => {
+        render(
+            <BrowserRouter>
+                <UpdatePassword />
+            </BrowserRouter>
+        );
+
+        const oldPasswordInput = screen.getByPlaceholderText('Old Password');
+        expect(oldPasswordInput).toHaveAttribute('type', 'password');
+
+        // Look for the toggle button specifically associated with old password
+        // Since we haven't implemented it yet, this test is expected to fail initially or we need to find it by a generic way first if we were TDDing strictly.
+        // However, we will look for the button by its aria-label which we plan to add.
+        const toggleBtn = screen.getByLabelText('Show old password');
+        fireEvent.click(toggleBtn);
+
+        expect(oldPasswordInput).toHaveAttribute('type', 'text');
+        expect(screen.getByLabelText('Hide old password')).toBeInTheDocument();
+
+        fireEvent.click(toggleBtn);
+        expect(oldPasswordInput).toHaveAttribute('type', 'password');
+    });
+
+    it('toggles password visibility for new password', () => {
+        render(
+            <BrowserRouter>
+                <UpdatePassword />
+            </BrowserRouter>
+        );
+
+        const newPasswordInput = screen.getByPlaceholderText('New Password');
+        expect(newPasswordInput).toHaveAttribute('type', 'password');
+
+        const toggleBtn = screen.getByLabelText('Show new password');
+        fireEvent.click(toggleBtn);
+
+        expect(newPasswordInput).toHaveAttribute('type', 'text');
+    });
+
+    it('toggles password visibility for confirm password', () => {
+        render(
+            <BrowserRouter>
+                <UpdatePassword />
+            </BrowserRouter>
+        );
+
+        const confirmPasswordInput = screen.getByPlaceholderText('Confirm Password');
+        expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+        const toggleBtn = screen.getByLabelText('Show confirm password');
+        fireEvent.click(toggleBtn);
+
+        expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+    });
+});

--- a/frontend/src/component/User/UpdatePassword.css
+++ b/frontend/src/component/User/UpdatePassword.css
@@ -52,6 +52,7 @@
 
 .updatePasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -73,6 +74,24 @@
   font-size: 1.2rem;
   color: var(--color-muted);
   pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 /* Redundant button class handled by primary-btn, kept for safety/overrides */

--- a/frontend/src/component/User/UpdatePassword.jsx
+++ b/frontend/src/component/User/UpdatePassword.jsx
@@ -9,6 +9,8 @@ import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
 import VpnKeyIcon from "@mui/icons-material/VpnKey"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate } from "react-router-dom";
 
 const UpdatePassword = () => {
@@ -21,6 +23,9 @@ const UpdatePassword = () => {
   const [oldPassword, setOldPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showOldPassword, setShowOldPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const updatePasswordSubmit = (e) => {
     e.preventDefault();
@@ -64,30 +69,57 @@ const UpdatePassword = () => {
               >
                 <div className='loginPassword'>
                   <VpnKeyIcon />
-                  <input type="password"
+                  <input
+                    type={showOldPassword ? "text" : "password"}
                     placeholder="Old Password"
                     required
                     value={oldPassword}
                     onChange={(e) => setOldPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowOldPassword(!showOldPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showOldPassword ? "Hide old password" : "Show old password"}
+                  >
+                    {showOldPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div className='loginPassword'>
                   <LockOpenIcon />
-                  <input type="password"
+                  <input
+                    type={showNewPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowNewPassword(!showNewPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showNewPassword ? "Hide new password" : "Show new password"}
+                  >
+                    {showNewPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div className='loginPassword'>
                   <LockIcon />
-                  <input type="password"
+                  <input
+                    type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <input
                   type="submit"


### PR DESCRIPTION
This PR adds a user-friendly password visibility toggle to the Update Password form. Users can now click an eye icon to reveal or mask their password input, reducing errors during password changes.

**Changes:**
- `frontend/src/component/User/UpdatePassword.jsx`: Added state for visibility toggles and inserted toggle buttons.
- `frontend/src/component/User/UpdatePassword.css`: Added styles for the toggle button and adjusted input padding.
- `frontend/src/__tests__/UpdatePassword_UX.test.jsx`: Added new unit tests to verify the feature.

**Verification:**
- Validated via new unit tests `UpdatePassword_UX.test.jsx` which pass successfully.
- Visual verification was attempted via Playwright but limited by authentication constraints in the dev environment; unit tests confirm DOM manipulation works as expected.

---
*PR created automatically by Jules for task [4421293851175169707](https://jules.google.com/task/4421293851175169707) started by @parilsanghvi*