### PR TITLE
🎨 Palette: Add focus-visible style to primary-btn

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,4 +52,4 @@
 
 ## 2025-05-27 - Button Focus Styles
 **Learning:** Found that `.primary-btn` explicitly removes `outline` without providing a fallback focus style, making keyboard navigation difficult.
-**Action:** When removing `outline` for aesthetic reasons, always ensure `focus-visible` styles are provided (e.g., `outline: 2px solid var(--color-secondary)`) to maintain accessibility.
+**Action:** When removing `outline` for aesthetic reasons, always ensure `focus-visible` styles are provided (e.g., `outline: 3px solid var(--color-secondary); outline-offset: 4px;`) to maintain accessibility.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -241,6 +241,11 @@ select:focus {
   box-shadow: 2px 2px 0 var(--color-text);
 }
 
+.primary-btn:focus-visible {
+  outline: 3px solid var(--color-secondary);
+  outline-offset: 4px;
+}
+
 .primary-btn:disabled {
   background-color: var(--color-muted);
   color: var(--color-bg);


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to `.primary-btn` class in `App.css`. Also added a learning journal entry about this accessibility issue.
🎯 Why: `.primary-btn` explicitly removed `outline` (`outline: none`) but failed to provide a fallback focus style, making keyboard navigation difficult or impossible for screen reader and keyboard-only users.
♿ Accessibility: Improved keyboard navigation by ensuring that buttons with `.primary-btn` class will have a visible outline (`3px solid var(--color-secondary)`) when focused via keyboard.

---
*PR created automatically by Jules for task [18182691125864483185](https://jules.google.com/task/18182691125864483185) started by @parilsanghvi*