### PR TITLE
🧪 Add Avatar Size Validation Unit Test

### DIFF
--- a/backend/tests/unit/userController_registerUser.test.js
+++ b/backend/tests/unit/userController_registerUser.test.js
@@ -1,0 +1,112 @@
+const userController = require('../../controllers/userController');
+const User = require('../../models/userModel');
+const cloudinary = require('cloudinary');
+const ErrorHandler = require('../../utlis/errorhandler');
+const sendToken = require('../../utlis/jwtToken');
+
+// Mock dependencies
+jest.mock('../../models/userModel');
+jest.mock('../../utlis/jwtToken');
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            upload: jest.fn(),
+        }
+    }
+}));
+// Mock catchAsyncErrors
+jest.mock('../../middleware/catchAsyncErrors', () => (func) => (req, res, next) => {
+    return Promise.resolve(func(req, res, next)).catch(next);
+});
+
+describe('registerUser Controller', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        req = {
+            body: {
+                name: 'Test User',
+                email: 'test@example.com',
+                password: 'password123',
+                avatar: 'data:image/jpeg;base64,validavatar'
+            }
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn()
+        };
+        next = jest.fn();
+        jest.clearAllMocks();
+    });
+
+    it('should register user successfully with valid avatar', async () => {
+        cloudinary.v2.uploader.upload.mockResolvedValue({
+            public_id: 'new_public_id',
+            secure_url: 'new_secure_url'
+        });
+
+        User.create.mockResolvedValue({
+            _id: 'user123',
+            name: 'Test User',
+            email: 'test@example.com'
+        });
+
+        await userController.registerUser(req, res, next);
+
+        expect(cloudinary.v2.uploader.upload).toHaveBeenCalledWith('data:image/jpeg;base64,validavatar', {
+            folder: "avatars",
+            width: 150,
+            crop: "scale",
+        });
+
+        expect(User.create).toHaveBeenCalledWith({
+            name: 'Test User',
+            email: 'test@example.com',
+            password: 'password123',
+            avatar: {
+                public_id: 'new_public_id',
+                url: 'new_secure_url',
+            }
+        });
+
+        expect(sendToken).toHaveBeenCalledWith(
+            expect.objectContaining({ _id: 'user123' }),
+            201,
+            res
+        );
+    });
+
+    it('should fail if avatar is missing', async () => {
+        req.body.avatar = undefined;
+
+        await userController.registerUser(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].statusCode).toBe(401);
+        expect(next.mock.calls[0][0].message).toBe("Please upload avatar");
+
+        // Ensure upload and create were not called
+        expect(cloudinary.v2.uploader.upload).not.toHaveBeenCalled();
+        expect(User.create).not.toHaveBeenCalled();
+        expect(sendToken).not.toHaveBeenCalled();
+    });
+
+    it('should fail if avatar size is too large (exceeds MAX_AVATAR_SIZE)', async () => {
+        // MAX_AVATAR_SIZE is 3 * 1024 * 1024 = 3145728
+        // Create a string slightly larger than MAX_AVATAR_SIZE
+        const MAX_AVATAR_SIZE = 3 * 1024 * 1024;
+        const largeAvatar = 'a'.repeat(MAX_AVATAR_SIZE + 1);
+        req.body.avatar = largeAvatar;
+
+        await userController.registerUser(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].statusCode).toBe(400);
+        expect(next.mock.calls[0][0].message).toBe("Avatar image size too large");
+
+        // Ensure upload and create were not called
+        expect(cloudinary.v2.uploader.upload).not.toHaveBeenCalled();
+        expect(User.create).not.toHaveBeenCalled();
+        expect(sendToken).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
🎯 **What:** 
Added a unit test for the `registerUser` backend controller specifically designed to verify the avatar payload size limitation logic (`MAX_AVATAR_SIZE = 3MB`). This code path was unreachable during normal integration tests due to the strict `express.json` size limit of 1MB, effectively failing the request before the controller logic could execute. This unit test ensures the internal safeguard is tested and acts correctly as a fallback.

📊 **Coverage:**
The new `backend/tests/unit/userController_registerUser.test.js` covers:
*   Happy Path: Successful registration using a valid avatar payload string.
*   Missing Avatar Edge Case: Verifies correct rejection (401 code) when the `req.body.avatar` is `undefined`.
*   Large Avatar Edge Case: Specifically constructs an avatar string larger than the threshold size (3MB), ensuring it gets properly rejected (400 code) with the `Avatar image size too large` message, and correctly verifies that `Cloudinary` and `User.create` functions are not executed.

✨ **Result:**
The `registerUser` controller now has complete unit testing for its fallback validation logics. The full test suite executes without regressions, improving overall coverage and guaranteeing this logic functions effectively.

---
*PR created automatically by Jules for task [16245025607938878809](https://jules.google.com/task/16245025607938878809) started by @parilsanghvi*