### PR TITLE
⚡ Bolt: [performance improvement] Concurrent delete and upload in processImagesUpdate

### DIFF
--- a/backend/tests/unit/benchmark_imageHandler2.test.js
+++ b/backend/tests/unit/benchmark_imageHandler2.test.js
@@ -1,0 +1,47 @@
+const { processImagesUpdate } = require('../../utlis/imageHandler');
+const cloudinary = require('cloudinary');
+
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            upload: jest.fn(),
+            destroy: jest.fn(),
+        },
+    },
+}));
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('processImagesUpdate benchmark', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('benchmark execution time - concurrent delete and upload', async () => {
+        const currentImages = Array.from({ length: 10 }, (_, i) => ({ public_id: `old_id${i}`, url: `http://old.com/img${i}.jpg` }));
+        const newImagesInput = Array.from({ length: 10 }, (_, i) => `data:image/jpeg;base64,new_image_data${i}`);
+
+        // Mock destroy to take 100ms
+        cloudinary.v2.uploader.destroy.mockImplementation(async () => {
+            await sleep(100);
+            return { result: 'ok' };
+        });
+
+        // Mock upload to take 100ms
+        cloudinary.v2.uploader.upload.mockImplementation(async () => {
+            await sleep(100);
+            return {
+                public_id: 'new_id',
+                secure_url: 'http://new.com/img.jpg',
+            };
+        });
+
+        const start = Date.now();
+        await processImagesUpdate(currentImages, newImagesInput);
+        const end = Date.now();
+
+        console.log(`Execution time concurrent: ${end - start}ms`);
+        // If it runs concurrently, the time should be around 100ms instead of 200ms
+        expect(end - start).toBeLessThan(150);
+    });
+});

--- a/backend/utlis/imageHandler.js
+++ b/backend/utlis/imageHandler.js
@@ -31,19 +31,21 @@ const processImagesUpdate = async (currentImages, newImagesInput) => {
     // Identify images to delete (present in DB but not in imagesToKeep)
     const imagesToDelete = currentImages.filter(img => !imagesToKeep.includes(img.url));
 
-    // Delete removed images from Cloudinary
-    await Promise.all(imagesToDelete.map(image => cloudinary.v2.uploader.destroy(image.public_id)));
-
-    // Upload new images
-    const newImagesLinks = await Promise.all(imagesToUpload.map(async (image) => {
-        const result = await cloudinary.v2.uploader.upload(image, {
-            folder: "products",
-        });
-        return {
-            public_id: result.public_id,
-            url: result.secure_url
-        };
-    }));
+    // ⚡ Bolt: Execute delete and upload operations concurrently to reduce total wait time
+    const [, newImagesLinks] = await Promise.all([
+        // Delete removed images from Cloudinary
+        Promise.all(imagesToDelete.map(image => cloudinary.v2.uploader.destroy(image.public_id))),
+        // Upload new images
+        Promise.all(imagesToUpload.map(async (image) => {
+            const result = await cloudinary.v2.uploader.upload(image, {
+                folder: "products",
+            });
+            return {
+                public_id: result.public_id,
+                url: result.secure_url
+            };
+        }))
+    ]);
 
     // Keep the old image objects that matched the URLs
     const keptImagesObjects = currentImages.filter(img => imagesToKeep.includes(img.url));


### PR DESCRIPTION
💡 **What:** 
Optimized the `processImagesUpdate` function in `backend/utlis/imageHandler.js` to execute Cloudinary image deletions and uploads concurrently using `Promise.all` rather than sequentially.

🎯 **Why:** 
Previously, the backend would wait for all image deletions to finish entirely before starting any new image uploads. Since these are two independent operations, they can be run in parallel to dramatically reduce the latency overhead when replacing images for resources.

📊 **Measured Improvement:** 
Added a dedicated benchmark test (`backend/tests/unit/benchmark_imageHandler2.test.js`).
*   **Baseline (Sequential):** Execution time ~204ms (assuming mock 100ms for delete + 100ms for upload).
*   **Improvement (Concurrent):** Execution time dropped to ~101ms (just slightly above the single longest operation time).
*   **Change:** Approximately a 50% reduction in total wait time for these operations, depending on network/Cloudinary conditions.

---
*PR created automatically by Jules for task [1332207452208814976](https://jules.google.com/task/1332207452208814976) started by @parilsanghvi*