### PR TITLE
🧹 [code health improvement] Extract slider arrow inline styles to CSS in ProductDetails

### DIFF
--- a/frontend/src/component/Product/ProductDetails.css
+++ b/frontend/src/component/Product/ProductDetails.css
@@ -295,3 +295,22 @@
   transform: translate(-2px, -2px);
   box-shadow: 6px 6px 0 var(--color-text);
 }
+/* Custom Slick Arrows */
+.slick-custom-arrow {
+  display: block;
+  color: var(--color-primary);
+  background: var(--color-surface);
+  border-radius: 50%;
+  border: 1px solid var(--color-text);
+  z-index: 2;
+  width: 40px;
+  height: 40px;
+}
+
+.slick-custom-next {
+  right: 10px;
+}
+
+.slick-custom-prev {
+  left: 10px;
+}

--- a/frontend/src/component/Product/ProductDetails.jsx
+++ b/frontend/src/component/Product/ProductDetails.jsx
@@ -29,19 +29,8 @@ const ProductDetails = () => {
     const { className, style, onClick } = props;
     return (
       <NavigateNextIcon
-        className={className}
-        style={{
-          ...style,
-          display: "block",
-          color: "var(--color-primary)",
-          background: "var(--color-surface)",
-          borderRadius: "50%",
-          border: "1px solid var(--color-text)",
-          zIndex: 2,
-          width: "40px",
-          height: "40px",
-          right: "10px"
-        }}
+        className={`${className} slick-custom-arrow slick-custom-next`}
+        style={style}
         onClick={onClick}
         role="button"
         aria-label="Next Slide"
@@ -53,19 +42,8 @@ const ProductDetails = () => {
     const { className, style, onClick } = props;
     return (
       <NavigateBeforeIcon
-        className={className}
-        style={{
-          ...style,
-          display: "block",
-          color: "var(--color-primary)",
-          background: "var(--color-surface)",
-          borderRadius: "50%",
-          border: "1px solid var(--color-text)",
-          zIndex: 2,
-          width: "40px",
-          height: "40px",
-          left: "10px"
-        }}
+        className={`${className} slick-custom-arrow slick-custom-prev`}
+        style={style}
         onClick={onClick}
         role="button"
         aria-label="Previous Slide"


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded inline styles from the `<NavigateNextIcon>` and `<NavigateBeforeIcon>` arrows in `frontend/src/component/Product/ProductDetails.jsx` into the `frontend/src/component/Product/ProductDetails.css` stylesheet using custom class names (`.slick-custom-arrow`, `.slick-custom-next`, `.slick-custom-prev`).

💡 **Why:** Inline styles reduce code maintainability, can negatively affect bundle sizes, and bypass the benefits of cached CSS files. Moving them into a stylesheet follows standard React best practices, keeps the component's JSX cleaner, prevents re-render thrashing from new inline object creation, and simplifies future theming or responsive changes.

✅ **Verification:**
1. Manually injected the appropriate `<svg>` elements into the test mock to verify the styling works via Playwright.
2. The entire frontend test suite was successfully executed using `cd frontend && npm run test`, confirming no tests were broken by this change.
3. Successfully ran `request_code_review` which evaluated the solution as `#Correct#`.
4. Confirmed the original `style` prop passed down from react-slick is properly preserved along with the custom classes.

✨ **Result:** Clean, CSS-driven slick arrows decoupled from the JSX component, drastically improving code readability and maintainability.

---
*PR created automatically by Jules for task [1012060892622360526](https://jules.google.com/task/1012060892622360526) started by @parilsanghvi*