### PR TITLE
⚡ Bolt: [performance improvement] Memoize cart subtotals

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2024-05-20 - Unbounded Array Performance Optimization
 **Learning:** Storing unbounded lists (like product reviews) as embedded arrays in MongoDB leads to massive document sizes, increased memory consumption, and severe O(N) penalties during read/write operations (e.g., finding a single review took ~240ms in an array of 10,000, vs. ~4.5ms in a separate indexed collection).
 **Action:** When designing or refactoring schemas for data that can grow indefinitely, always move the data to a separate, indexed collection. Keep fast-aggregation statistics (like `numOfReviews` and `ratings`) embedded in the parent document. To maintain API backward compatibility, configure Mongoose virtuals on the parent schema to allow `.populate()` calls.
+
+## 2025-03-01 - Cart Subtotal Calculation Optimization
+**Learning:** React re-evaluates synchronous array computations (like `reduce` to calculate `grossTotal` and `subtotal`) during every component render. Since components like `Cart` or `ConfirmOrder` often have highly dynamic elements (e.g. quantity changes causing frequent state updates), this creates a performance bottleneck as the cart grows.
+**Action:** When working with derived state calculated from expensive array operations (like calculating subtotals on `cartItems`), always wrap the logic in a `useMemo` hook with strict dependencies.

--- a/frontend/src/component/Cart/Cart.jsx
+++ b/frontend/src/component/Cart/Cart.jsx
@@ -7,13 +7,21 @@ import { Typography, Tooltip, CircularProgress } from "@mui/material";
 import RemoveShoppingCartIcon from "@mui/icons-material/RemoveShoppingCart";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 const Cart = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { cartItems } = useSelector((state) => state.cart);
   const [updatingItems, setUpdatingItems] = useState({});
+
+  // Optimize: Memoize gross total calculation to avoid re-calculating on every render
+  const grossTotal = useMemo(() => {
+    return cartItems.reduce(
+      (acc, item) => acc + item.quantity * item.price,
+      0
+    );
+  }, [cartItems]);
 
   const increaseQuantity = async (id, quantity, stock) => {
     const newQty = quantity + 1;
@@ -138,10 +146,7 @@ const Cart = () => {
           <div className="cartFooter">
             <div className="cartGrossProfitBox">
               <p>GROSS TOTAL</p>
-              <p>{`₹${cartItems.reduce(
-                (acc, item) => acc + item.quantity * item.price,
-                0
-              )}`}</p>
+              <p>{`₹${grossTotal}`}</p>
             </div>
             <button className="primary-btn" onClick={checkoutHandler}>CHECK OUT NOW</button>
           </div>

--- a/frontend/src/component/Cart/ConfirmOrder.jsx
+++ b/frontend/src/component/Cart/ConfirmOrder.jsx
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from "../../config";
-import React, { Fragment, useState, useEffect } from "react";
+import React, { Fragment, useState, useEffect, useMemo } from "react";
 import CheckoutSteps from "../Cart/CheckoutSteps";
 import { useSelector } from "react-redux";
 import MetaData from "../layout/MetaData";
@@ -20,10 +20,13 @@ const ConfirmOrder = () => {
   });
   const [loading, setLoading] = useState(false);
 
-  const subtotal = cartItems.reduce(
-    (acc, item) => acc + item.quantity * item.price,
-    0
-  );
+  // Optimize: Memoize subtotal calculation to avoid re-calculating on every render
+  const subtotal = useMemo(() => {
+    return cartItems.reduce(
+      (acc, item) => acc + item.quantity * item.price,
+      0
+    );
+  }, [cartItems]);
 
   const { tax, shippingCharges, totalPrice } = pricing;
 


### PR DESCRIPTION
💡 **What**: Wrapped the `cartItems.reduce()` calculations for `grossTotal` in `Cart.jsx` and `subtotal` in `ConfirmOrder.jsx` with React's `useMemo` hook.

🎯 **Why**: Array `reduce` operations run synchronously on every render. Because components like the `Cart` update state frequently (e.g. toggling loading spinners on individual quantity inputs), this leads to redundant mathematical calculations over the entire array on every tiny interaction, causing a performance bottleneck as the cart grows.

📊 **Impact**: Prevents redundant O(N) recalculations on unrelated state updates. `useMemo` guarantees the math only happens when `cartItems` is actually mutated, reducing CPU overhead during UI re-renders.

🔬 **Measurement**: Verify by using React DevTools Profiler while modifying item quantities. Render times for the parent component will remain flat regardless of the length of `cartItems` when internal non-cart state changes (like `updatingItems` toggle).

---
*PR created automatically by Jules for task [662142804845898167](https://jules.google.com/task/662142804845898167) started by @parilsanghvi*