### PR TITLE
🎨 Palette: Add aria-label to image removal button

### DIFF
--- a/frontend/src/component/Admin/UpdateProduct.jsx
+++ b/frontend/src/component/Admin/UpdateProduct.jsx
@@ -231,6 +231,7 @@ const UpdateProduct = () => {
                 <img src={image} alt="Product Preview" style={{ border: '2px solid var(--color-border)', width: '5vmax', height: '5vmax', objectFit: 'cover' }} />
                 <button
                   type="button"
+                  aria-label="Remove image"
                   onClick={() => removeImage(index)}
                   style={{
                     position: 'absolute',


### PR DESCRIPTION
💡 **What:**
Added an `aria-label="Remove image"` to the "X" button used to remove product preview images in the `UpdateProduct` admin component.

🎯 **Why:**
The button previously only contained the text "X", which is not descriptive enough for users relying on screen readers to understand the button's function.

♿ **Accessibility:**
Improved screen reader experience by providing clear, descriptive text for a functional button, following a11y best practices for icon-like or vaguely-texted buttons.

---
*PR created automatically by Jules for task [14995176118976813951](https://jules.google.com/task/14995176118976813951) started by @parilsanghvi*