### PR TITLE
⚡ Bolt: Memoize cart item total calculations

### DIFF
--- a/frontend/src/component/Cart/Cart.jsx
+++ b/frontend/src/component/Cart/Cart.jsx
@@ -7,7 +7,7 @@ import { Typography, Tooltip, CircularProgress } from "@mui/material";
 import RemoveShoppingCartIcon from "@mui/icons-material/RemoveShoppingCart";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 const Cart = () => {
   const dispatch = useDispatch();
@@ -56,6 +56,13 @@ const Cart = () => {
   const checkoutHandler = () => {
     navigate("/login?redirect=/shipping");
   };
+
+  const grossTotal = useMemo(() => {
+    return cartItems.reduce(
+      (acc, item) => acc + item.quantity * item.price,
+      0
+    );
+  }, [cartItems]);
 
   return (
     <Fragment>
@@ -138,10 +145,7 @@ const Cart = () => {
           <div className="cartFooter">
             <div className="cartGrossProfitBox">
               <p>GROSS TOTAL</p>
-              <p>{`₹${cartItems.reduce(
-                (acc, item) => acc + item.quantity * item.price,
-                0
-              )}`}</p>
+              <p>{`₹${grossTotal}`}</p>
             </div>
             <button className="primary-btn" onClick={checkoutHandler}>CHECK OUT NOW</button>
           </div>

--- a/frontend/src/component/Cart/ConfirmOrder.jsx
+++ b/frontend/src/component/Cart/ConfirmOrder.jsx
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from "../../config";
-import React, { Fragment, useState, useEffect } from "react";
+import React, { Fragment, useState, useEffect, useMemo } from "react";
 import CheckoutSteps from "../Cart/CheckoutSteps";
 import { useSelector } from "react-redux";
 import MetaData from "../layout/MetaData";
@@ -20,10 +20,12 @@ const ConfirmOrder = () => {
   });
   const [loading, setLoading] = useState(false);
 
-  const subtotal = cartItems.reduce(
-    (acc, item) => acc + item.quantity * item.price,
-    0
-  );
+  const subtotal = useMemo(() => {
+    return cartItems.reduce(
+      (acc, item) => acc + item.quantity * item.price,
+      0
+    );
+  }, [cartItems]);
 
   const { tax, shippingCharges, totalPrice } = pricing;
 


### PR DESCRIPTION
💡 **What:** Wrapped the `cartItems.reduce(...)` calculation for the total and subtotal amounts inside `useMemo` hooks in both `Cart.jsx` and `ConfirmOrder.jsx`.

🎯 **Why:** Derived state calculated from expensive array operations like `reduce` runs synchronously on every render. If these components re-render often (for example, due to local UI state changes like loading spinners or input updates while adjusting quantities), this becomes a bottleneck.

📊 **Impact:** Reduces main-thread blocking time during re-renders by skipping the recalculation of the cart totals when the cart items haven't changed.

🔬 **Measurement:** Verify by placing a `console.log` inside the `useMemo` callback; notice it only logs when cart items are added, removed, or quantities change, instead of every single component re-render.

---
*PR created automatically by Jules for task [8386014187857877992](https://jules.google.com/task/8386014187857877992) started by @parilsanghvi*