### PR TITLE
🎨 Palette: Add aria-label to order details link

### DIFF
--- a/frontend/src/component/Order/MyOrders.jsx
+++ b/frontend/src/component/Order/MyOrders.jsx
@@ -56,7 +56,7 @@ const MyOrders = () => {
       sortable: false,
       renderCell: (params) => {
         return (
-          <Link to={`/order/${params.row.id}`}>
+          <Link to={`/order/${params.row.id}`} aria-label="View Order Details">
             <LaunchIcon />
           </Link>
         );


### PR DESCRIPTION
**💡 What:**
Added `aria-label="View Order Details"` to the `<Link>` wrapping the `<LaunchIcon />` in the `MyOrders.jsx` data grid table.

**🎯 Why:**
This is a micro-UX and accessibility enhancement. Icon-only links within tables are notoriously unhelpful for screen readers because they lack descriptive text. Adding this `aria-label` ensures screen reader users understand the purpose of this action button.

**♿ Accessibility:**
- Makes the "Actions" column fully accessible by defining the link's purpose for assistive technologies.

*All frontend unit test suites pass successfully.*

---
*PR created automatically by Jules for task [16160137705862408001](https://jules.google.com/task/16160137705862408001) started by @parilsanghvi*