### PR TITLE
🛡️ Sentinel: [HIGH] Fix inventory tampering via duplicate shipped status

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -227,6 +227,10 @@ exports.updateOrder = catchAsyncErrors(async (req, res, next) => {
         return next(new ErrorHandler("you have recieved order", 400))
     }
 
+    if (order.orderStatus === "Shipped" && req.body.status === "Shipped") {
+        return next(new ErrorHandler("Order has already been shipped", 400));
+    }
+
 
     if (req.body.status === "Shipped") {
         const operations = order.orderItems.map((item) => ({

--- a/backend/tests/integration/review.test.js
+++ b/backend/tests/integration/review.test.js
@@ -7,6 +7,7 @@ const Product = require('../../models/productModel');
 const Review = require('../../models/reviewModel');
 
 let mongoServer;
+jest.setTimeout(30000);
 let userCookie;
 let adminCookie;
 let testProduct;

--- a/backend/tests/unit/myOrders_optimization.test.js
+++ b/backend/tests/unit/myOrders_optimization.test.js
@@ -5,6 +5,7 @@ const User = require('../../models/userModel');
 
 // Mock catchAsyncErrors to allow awaiting the controller function directly
 jest.mock('../../middleware/catchAsyncErrors', () => (func) => (req, res, next) => func(req, res, next));
+jest.setTimeout(30000);
 
 // Mock Stripe before requiring controller
 jest.mock('stripe', () => {

--- a/backend/tests/unit/stock_update.test.js
+++ b/backend/tests/unit/stock_update.test.js
@@ -97,4 +97,25 @@ describe('updateOrder Stock Update Security', () => {
         // Verify response was NOT sent
         expect(res.status).not.toHaveBeenCalled();
     });
+
+    it('should throw error and NOT update stock if order is already Shipped', async () => {
+        const mockOrder = {
+            orderStatus: 'Shipped',
+            orderItems: [
+                { product: 'prod1', quantity: 2 }
+            ],
+            save: jest.fn()
+        };
+
+        Order.findById.mockResolvedValue(mockOrder);
+
+        await updateOrder(req, res, next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(next.mock.calls[0][0].message).toBe('Order has already been shipped');
+        expect(next.mock.calls[0][0].statusCode).toBe(400);
+
+        expect(Product.bulkWrite).not.toHaveBeenCalled();
+        expect(mockOrder.save).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** An admin could send the `status: "Shipped"` update multiple times for an order that was already shipped. The system failed to check if the order was already in the "Shipped" status, resulting in duplicate subtractions from the product's inventory stock for each subsequent request.
🎯 **Impact:** Malicious actors or unintentional duplicate requests (e.g., UI retries) could rapidly deplete product stock to zero or negative values, causing a Denial of Service (DoS) by rendering items unpurchasable for legitimate users.
🔧 **Fix:** Added a state validation check in `backend/controllers/orderController.js` that returns a 400 Bad Request error if the `order.orderStatus` is already "Shipped" and the incoming `req.body.status` is also "Shipped".
✅ **Verification:** A new dedicated unit test was added to `backend/tests/unit/stock_update.test.js` to ensure subsequent "Shipped" statuses trigger an `ErrorHandler` instead of executing a `bulkWrite` stock deduction. The full backend test suite passes successfully.

---
*PR created automatically by Jules for task [16601483650495465993](https://jules.google.com/task/16601483650495465993) started by @parilsanghvi*