### PR TITLE
⚡ Bolt: [performance improvement] Memoize DataGrid columns and rows to prevent expensive re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2025-03-03 - Memoizing Array Reductions in React Components
 **Learning:** `Cart.jsx` and `ConfirmOrder.jsx` were recalculating derived state (like `grossTotal` or `subtotal`) by calling `cartItems.reduce()` directly inside the component's render body. This recalculation executes on every render, which becomes a bottleneck during frequent state updates like changing item quantities or showing loading spinners.
 **Action:** Always wrap expensive operations like `Array.prototype.reduce`, `map`, or `filter` inside a `useMemo` hook with strict dependencies when calculating derived state in React components to prevent unnecessary re-evaluations.
+
+## 2025-03-04 - Memoizing DataGrid Columns and Rows
+**Learning:** When using `@mui/x-data-grid`, the `columns` prop acts as the definition for the entire grid. If the `columns` array is created inline during render, its reference changes on every component re-render. This forces the entire DataGrid component to needlessly unmount/remount internal components and causes the loss of all UI state (such as resized column widths). Similarly, reconstructing the `rows` array directly in the render body causes an O(N) operation to execute repetitively.
+**Action:** Always wrap the `columns` definition array in a `useMemo` hook (remembering to also `useCallback` any inline event handlers referenced by it, like `deleteProductHandler`) and wrap the `rows` construction in `useMemo` to ensure referential stability.

--- a/frontend/src/component/Admin/OrderList.jsx
+++ b/frontend/src/component/Admin/OrderList.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState, useMemo, useCallback } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import "./productList.css";
 import { useSelector, useDispatch } from "react-redux";
@@ -28,9 +28,10 @@ const OrderList = () => {
 
   const { error: deleteError, isDeleted } = useSelector((state) => state.order);
 
-  const deleteOrderHandler = (id) => {
+  // ⚡ Bolt: [performance improvement] Memoize the delete handler to prevent inline function recreation inside columns
+  const deleteOrderHandler = useCallback((id) => {
     dispatch(deleteOrder(id));
-  };
+  }, [dispatch]);
 
   const setCurrentPageNo = (e, value) => {
     setCurrentPage(value);
@@ -51,7 +52,8 @@ const OrderList = () => {
     }
   }, [dispatch, enqueueSnackbar, navigate, isDeleted]);
 
-  const columns = [
+  // ⚡ Bolt: [performance improvement] Memoize DataGrid columns to prevent complete remounts and lost UI state (like column resize)
+  const columns = useMemo(() => [
     { field: "id", headerName: "Order ID", minWidth: 300, flex: 1 },
 
     {
@@ -100,19 +102,23 @@ const OrderList = () => {
         );
       },
     },
-  ];
+  ], [deleteOrderHandler]);
 
-  const rows = [];
-
-  orders &&
-    orders.forEach((item) => {
-      rows.push({
-        id: item._id,
-        itemsQty: item.orderItems.length,
-        amount: item.totalPrice,
-        status: item.orderStatus,
+  // ⚡ Bolt: [performance improvement] Memoize rows array construction to prevent O(N) execution on every component render
+  const rows = useMemo(() => {
+    const rowData = [];
+    if (orders) {
+      orders.forEach((item) => {
+        rowData.push({
+          id: item._id,
+          itemsQty: item.orderItems.length,
+          amount: item.totalPrice,
+          status: item.orderStatus,
+        });
       });
-    });
+    }
+    return rowData;
+  }, [orders]);
 
   return (
     <AdminLayout title={`ALL ORDERS - Admin`}>

--- a/frontend/src/component/Admin/ProductList.jsx
+++ b/frontend/src/component/Admin/ProductList.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from "react";
+import React, { Fragment, useEffect, useMemo, useCallback } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import "./productList.css";
 import { useSelector, useDispatch } from "react-redux";
@@ -28,9 +28,10 @@ const ProductList = () => {
     (state) => state.product
   );
 
-  const deleteProductHandler = (id) => {
+  // ⚡ Bolt: [performance improvement] Memoize the delete handler to prevent inline function recreation inside columns
+  const deleteProductHandler = useCallback((id) => {
     dispatch(deleteProduct(id));
-  };
+  }, [dispatch]);
 
   useErrorNotification(error, clearErrors);
   useErrorNotification(deleteError, clearErrors);
@@ -47,7 +48,8 @@ const ProductList = () => {
     }
   }, [dispatch, enqueueSnackbar, navigate, isDeleted]);
 
-  const columns = [
+  // ⚡ Bolt: [performance improvement] Memoize DataGrid columns to prevent complete remounts and lost UI state (like column resize)
+  const columns = useMemo(() => [
     { field: "id", headerName: "Product ID", minWidth: 200, flex: 0.5 },
 
     {
@@ -98,19 +100,23 @@ const ProductList = () => {
         );
       },
     },
-  ];
+  ], [deleteProductHandler]);
 
-  const rows = [];
-
-  products &&
-    products.forEach((item) => {
-      rows.push({
-        id: item._id,
-        stock: item.stock,
-        price: item.price,
-        name: item.name,
+  // ⚡ Bolt: [performance improvement] Memoize rows array construction to prevent O(N) execution on every component render
+  const rows = useMemo(() => {
+    const rowData = [];
+    if (products) {
+      products.forEach((item) => {
+        rowData.push({
+          id: item._id,
+          stock: item.stock,
+          price: item.price,
+          name: item.name,
+        });
       });
-    });
+    }
+    return rowData;
+  }, [products]);
 
   return (
     <AdminLayout title={`ALL PRODUCTS - Admin`}>


### PR DESCRIPTION
💡 What: The optimization implements `useMemo` for the `columns` and `rows` props passed to the MUI DataGrid components in `ProductList.jsx` and `OrderList.jsx`, and `useCallback` for their associated inline event handlers.

🎯 Why: MUI's `DataGrid` component uses the reference of the `columns` array to perform extensive internal caching and UI state management (like column widths). If the array is defined directly inside the render body without memoization, its reference changes on every re-render of the parent component. This forces the grid to undergo a complete, expensive internal remount and causes a loss of all UI state. Similarly, generating the `rows` array via an unmemoized `forEach` loop executes an unnecessary O(N) operation on every render.

📊 Impact: Reduces expensive DOM reconciliations, eliminates O(N) loop executions on generic component re-renders, and completely prevents UI state bugs associated with column resizing.

🔬 Measurement: Tested via Vite frontend tests to ensure `deleteProduct` and `deleteOrder` actions still correctly trigger component state updates without breaking the grid.

---
*PR created automatically by Jules for task [13783575175947136197](https://jules.google.com/task/13783575175947136197) started by @parilsanghvi*