### PR TITLE
⚡ Bolt: [performance improvement] Optimize Stripe Initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2025-03-03 - Memoizing Array Reductions in React Components
 **Learning:** `Cart.jsx` and `ConfirmOrder.jsx` were recalculating derived state (like `grossTotal` or `subtotal`) by calling `cartItems.reduce()` directly inside the component's render body. This recalculation executes on every render, which becomes a bottleneck during frequent state updates like changing item quantities or showing loading spinners.
 **Action:** Always wrap expensive operations like `Array.prototype.reduce`, `map`, or `filter` inside a `useMemo` hook with strict dependencies when calculating derived state in React components to prevent unnecessary re-evaluations.
+
+## 2025-03-03 - Stripe Elements Initialization Performance
+**Learning:** Calling `loadStripe(apiKey)` directly within the `<Elements stripe={...}>` prop causes the Stripe object to re-initialize and inject heavy external scripts/iframes on every render of the parent component.
+**Action:** Always call `loadStripe(apiKey)` once and store the resulting Promise in a React state variable (e.g., `stripePromise`), passing that state to the `<Elements>` provider to ensure referential stability.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,12 +47,12 @@ const About = lazy(() => import("./component/layout/About/About"));
 
 function App() {
 
-  const [stripeApiKey, setStripeApiKey] = useState("");
+  const [stripePromise, setStripePromise] = useState(null);
 
   async function getStripeApiKey() {
     try {
       const { data } = await axios.get(`${API_BASE_URL}/stripeapikey`);
-      setStripeApiKey(data.stripeApiKey);
+      setStripePromise(loadStripe(data.stripeApiKey));
     } catch (error) {
       console.log("Stripe API key not found or backend unreachable");
     }
@@ -94,8 +94,8 @@ function App() {
           <Route
             path="/process/payment"
             element={
-              stripeApiKey ? (
-                <Elements stripe={loadStripe(stripeApiKey)}>
+              stripePromise ? (
+                <Elements stripe={stripePromise}>
                   <ProtectedRoute>
                     <Payment />
                   </ProtectedRoute>


### PR DESCRIPTION
💡 What: Lifted `loadStripe(apiKey)` out of the render loop and stored the resulting Promise in a referentially stable React state variable (`stripePromise`).
🎯 Why: Calling `loadStripe` inline directly inside the `<Elements stripe={...}>` prop causes the heavy Stripe object (and associated external iframes) to be recreated on every single re-render of the App component, leading to degraded frontend performance and potential UI payment glitches.
📊 Impact: Eliminates redundant Stripe initializations and network/iframe rebuilds during routing and global state updates.
🔬 Measurement: Verify frontend test suite passes and manually ensure no console warnings exist about multiple Stripe objects.

---
*PR created automatically by Jules for task [11633022139125319573](https://jules.google.com/task/11633022139125319573) started by @parilsanghvi*