### PR TITLE
🎨 Palette: Add loading state to payment submit button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -53,3 +53,7 @@
 ## 2025-05-27 - Button Focus Styles
 **Learning:** Found that `.primary-btn` explicitly removes `outline` without providing a fallback focus style, making keyboard navigation difficult.
 **Action:** When removing `outline` for aesthetic reasons, always ensure `focus-visible` styles are provided (e.g., `outline: 3px solid var(--color-secondary); outline-offset: 4px;`) to maintain accessibility.
+
+## 2025-05-27 - Forms Without Buttons
+**Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
+**Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -70,7 +70,7 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByDisplayValue('Pay - ₹118')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Pay - ₹118/i })).toBeInTheDocument();
     });
 
     it('renders checkout steps', () => {

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -3,7 +3,7 @@ import React, { Fragment, useEffect, useRef, useState } from "react";
 import CheckoutSteps from "../Cart/CheckoutSteps";
 import { useSelector, useDispatch } from "react-redux";
 import MetaData from "../layout/MetaData";
-import { Typography } from "@mui/material";
+import { Typography, CircularProgress } from "@mui/material";
 import { useSnackbar } from "notistack";
 import {
   CardNumberElement,
@@ -34,6 +34,8 @@ const Payment = () => {
   const { shippingInfo, cartItems } = useSelector((state) => state.cart);
   const { user } = useSelector((state) => state.user);
   const { error } = useSelector((state) => state.order);
+
+  const [isProcessing, setIsProcessing] = useState(false);
 
   // Detect theme for Stripe Elements styling
   const [isDarkMode, setIsDarkMode] = useState(true);
@@ -92,6 +94,7 @@ const Payment = () => {
     e.preventDefault();
 
     payBtn.current.disabled = true;
+    setIsProcessing(true);
 
     try {
       const config = {
@@ -128,6 +131,7 @@ const Payment = () => {
 
       if (result.error) {
         payBtn.current.disabled = false;
+        setIsProcessing(false);
 
         enqueueSnackbar(result.error.message, { variant: "error" });
       } else {
@@ -144,6 +148,7 @@ const Payment = () => {
           }
           navigate("/success");
         } else {
+          setIsProcessing(false);
           enqueueSnackbar("There's some issue while processing payment ", {
             variant: "error",
           });
@@ -151,6 +156,7 @@ const Payment = () => {
       }
     } catch (error) {
       payBtn.current.disabled = false;
+      setIsProcessing(false);
       enqueueSnackbar(error.response.data.message, { variant: "error" });
     }
   };
@@ -182,12 +188,15 @@ const Payment = () => {
             <CardCvcElement className="paymentInput" options={stripeElementStyle} />
           </div>
 
-          <input
+          <button
             type="submit"
-            value={`Pay - ₹${orderInfo && orderInfo.totalPrice}`}
             ref={payBtn}
             className="primary-btn paymentFormBtn"
-          />
+            disabled={isProcessing}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '10px' }}
+          >
+            {isProcessing ? <CircularProgress size={20} color="inherit" /> : `Pay - ₹${orderInfo && orderInfo.totalPrice}`}
+          </button>
         </form>
       </div>
     </Fragment>


### PR DESCRIPTION
💡 **What:** Replaced the static `<input type="submit">` element in the Payment component with a `<button type="submit">` and a Material UI `CircularProgress` component. A new `isProcessing` state toggles this loading spinner during the Stripe payment request. Also updated the associated unit test to query by the `button` role instead of the display value.

🎯 **Why:** Previously, submitting the payment form gave no immediate visual feedback, leading to a poor user experience during long-running async tasks (Stripe processing). By using a proper button element with a loading state, users are now assured the system is working and the button is disabled, preventing double-clicks or confusion.

♿ **Accessibility:**
- Refactored away from legacy input submits to semantic button elements.
- Associated the loading state logically with the action being performed.

---
*PR created automatically by Jules for task [11800913780299255764](https://jules.google.com/task/11800913780299255764) started by @parilsanghvi*