### PR TITLE
🧹 [Code Health] Remove unused error argument in catch block

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,7 +53,7 @@ function App() {
     try {
       const { data } = await axios.get(`${API_BASE_URL}/stripeapikey`);
       setStripeApiKey(data.stripeApiKey);
-    } catch (error) {
+    } catch {
       console.log("Stripe API key not found or backend unreachable");
     }
   }


### PR DESCRIPTION
🎯 **What:** The `catch` block in `frontend/src/App.jsx` `getStripeApiKey` function contained an unused `error` parameter.
💡 **Why:** By leveraging ES2019 optional catch binding (`catch {`), the unused `error` parameter is removed, cleaning up the code and adhering to modern JS practices without changing any behavior. This improves maintainability and readability by signaling to other developers that the exact error value is not critical or utilized in this specific catch block.
✅ **Verification:** I ran the frontend unit test suite (`cd frontend && npm install && npm run test -- --run`) to verify that the application still behaves correctly and no regressions were introduced.
✨ **Result:** A small, safe code health improvement replacing `} catch (error) {` with `} catch {`.

---
*PR created automatically by Jules for task [15681477610977399779](https://jules.google.com/task/15681477610977399779) started by @parilsanghvi*