### PR TITLE
🧹 Code Health: Use console.error instead of console.log for errors in server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -4,8 +4,8 @@ const cloudinary = require("cloudinary")
 const connectDatabase = require('./config/database')
 // handling uncaught exception
 process.on("uncaughtException", (err) => {
-    console.log(`error: ${err.message}`);
-    console.log("shutting down server due to uncaughtException");
+    console.error(`error: ${err.message}`);
+    console.error("shutting down server due to uncaughtException");
     process.exit(1);
 })
 // config
@@ -26,8 +26,8 @@ connectDatabase().then(() => {
 
     // unhandled promise rejection
     process.on("unhandledRejection", err => {
-        console.log(`error: ${err.message}`);
-        console.log("shutting down server due to unhandled promise rejection");
+        console.error(`error: ${err.message}`);
+        console.error("shutting down server due to unhandled promise rejection");
         server.close(() => {
             process.exit(1);
         });


### PR DESCRIPTION
🎯 **What:** Modified `backend/server.js` to use `console.error` instead of `console.log` for logging unhandled promise rejections and uncaught exceptions.

💡 **Why:** Using `console.error` for standard error output ensures better logging and monitoring practices. It directs errors to stderr, which is expected behavior for issues like crashes and unhandled exceptions.

✅ **Verification:** Verified that the changes accurately reflect using `console.error`. Executed `npx jest backend/tests/` to run all backend test suites and confirmed all 233 tests across 73 test suites passed successfully, demonstrating no regressions in behavior. 

✨ **Result:** Improved codebase maintainability and logging conventions.

---
*PR created automatically by Jules for task [9673421321145791653](https://jules.google.com/task/9673421321145791653) started by @parilsanghvi*