### PR TITLE
🧪 Add tests for getAdminProduct async thunk

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,6 @@
         "react-router-dom": "^6.22.0",
         "react-slick": "^0.31.0",
         "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
         "slick-carousel": "^1.8.1",
         "web-vitals": "^5.1.0"
       },
@@ -49,6 +48,8 @@
         "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.0.18",
         "jsdom": "^28.0.0",
+        "redux-mock-store": "^1.5.5",
+        "redux-thunk": "^3.1.0",
         "vite": "^7.3.1",
         "vite-plugin-env-compatible": "^2.0.1",
         "vitest": "^4.0.18"
@@ -3872,6 +3873,13 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4469,6 +4477,19 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.5.tgz",
+      "integrity": "sha512-YxX+ofKUTQkZE4HbhYG4kKGr7oCTJfB0GLy7bSeqx86GLpGirrbUWstMnqXkqHNaQpcnbMGbof2dYs5KsPE6Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
+      },
+      "peerDependencies": {
+        "redux": "*"
+      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "react-router-dom": "^6.22.0",
     "react-slick": "^0.31.0",
     "redux": "^5.0.1",
-    "redux-thunk": "^3.1.0",
     "slick-carousel": "^1.8.1",
     "web-vitals": "^5.1.0"
   },
@@ -51,6 +50,8 @@
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.0.18",
     "jsdom": "^28.0.0",
+    "redux-mock-store": "^1.5.5",
+    "redux-thunk": "^3.1.0",
     "vite": "^7.3.1",
     "vite-plugin-env-compatible": "^2.0.1",
     "vitest": "^4.0.18"

--- a/frontend/src/__tests__/slices/productSlice.test.js
+++ b/frontend/src/__tests__/slices/productSlice.test.js
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import configureMockStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
 import productReducer, {
     clearErrors,
     newProductReset,
@@ -7,6 +10,7 @@ import productReducer, {
     newReviewReset,
     deleteReviewReset,
     getProduct,
+    getAdminProduct,
     getProductDetails,
     createProduct,
     updateProduct,
@@ -15,6 +19,11 @@ import productReducer, {
     getAllReviews,
     deleteReviews,
 } from '../../features/productSlice';
+
+vi.mock('axios');
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 const initialState = {
     products: [],
@@ -95,6 +104,71 @@ describe('productSlice', () => {
             const result = productReducer(initialState, action);
             expect(result.loading).toBe(false);
             expect(result.error).toBe('Failed to fetch');
+        });
+    });
+
+    describe('getAdminProduct async thunk behavior', () => {
+        let store;
+
+        beforeEach(() => {
+            store = mockStore({});
+            vi.clearAllMocks();
+        });
+
+        it('dispatches pending and fulfilled actions on successful API call', async () => {
+            const mockData = {
+                data: {
+                    products: [{ _id: '1', name: 'Admin Product 1' }, { _id: '2', name: 'Admin Product 2' }]
+                }
+            };
+
+            axios.get.mockResolvedValueOnce(mockData);
+
+            await store.dispatch(getAdminProduct());
+
+            const actions = store.getActions();
+
+            expect(actions[0].type).toBe(getAdminProduct.pending.type);
+            expect(actions[1].type).toBe(getAdminProduct.fulfilled.type);
+            expect(actions[1].payload).toEqual(mockData.data.products);
+        });
+
+        it('dispatches pending and rejected actions on failed API call', async () => {
+            const mockError = new Error('Network Error');
+            mockError.response = { data: { message: 'Server is down' } };
+
+            axios.get.mockRejectedValueOnce(mockError);
+
+            await store.dispatch(getAdminProduct());
+
+            const actions = store.getActions();
+
+            expect(actions[0].type).toBe(getAdminProduct.pending.type);
+            expect(actions[1].type).toBe(getAdminProduct.rejected.type);
+            expect(actions[1].payload).toBe('Server is down');
+        });
+    });
+
+    describe('getAdminProduct async thunk reducers', () => {
+        it('should set loading on pending', () => {
+            const action = { type: getAdminProduct.pending.type };
+            const result = productReducer(initialState, action);
+            expect(result.loading).toBe(true);
+        });
+
+        it('should populate products on fulfilled', () => {
+            const payload = [{ _id: '1', name: 'Admin Product' }];
+            const action = { type: getAdminProduct.fulfilled.type, payload };
+            const result = productReducer(initialState, action);
+            expect(result.loading).toBe(false);
+            expect(result.products).toEqual(payload);
+        });
+
+        it('should set error on rejected', () => {
+            const action = { type: getAdminProduct.rejected.type, payload: 'Failed to fetch admin products' };
+            const result = productReducer(initialState, action);
+            expect(result.loading).toBe(false);
+            expect(result.error).toBe('Failed to fetch admin products');
         });
     });
 


### PR DESCRIPTION
🎯 What: The `getAdminProduct` async thunk was missing tests.
📊 Coverage: Added tests to ensure actions (pending, fulfilled, rejected) are dispatched properly, handling successful and failed API responses using `redux-mock-store` and `axios` mocks. Additionally, covered reducer logic for the three action types.
✨ Result: The thunk is now fully tested, preventing potential regressions and improving the reliability of the product slice.

---
*PR created automatically by Jules for task [16585148890500405065](https://jules.google.com/task/16585148890500405065) started by @parilsanghvi*