### PR TITLE
🧪 Add unit tests for updateUserRole admin function

### DIFF
--- a/backend/tests/userController_updateUserRole.test.js
+++ b/backend/tests/userController_updateUserRole.test.js
@@ -1,0 +1,160 @@
+jest.mock('resend', () => ({
+    Resend: jest.fn().mockImplementation(() => ({
+        emails: {
+            send: jest.fn().mockResolvedValue({}),
+        },
+    })),
+}), { virtual: true });
+
+jest.mock('../utils/sendEmail', () => jest.fn());
+
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            upload: jest.fn(),
+            destroy: jest.fn(),
+        },
+    },
+}), { virtual: true });
+
+// Mocks must be defined before use
+jest.mock('../models/userModel', () => ({
+    findByIdAndUpdate: jest.fn(),
+}));
+
+const { updateUserRole } = require('../controllers/userController');
+const User = require('../models/userModel');
+
+const mockRequest = () => {
+    const req = {};
+    req.body = {};
+    req.params = {};
+    return req;
+};
+
+const mockResponse = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+};
+
+const mockNext = jest.fn();
+
+describe('User Controller - updateUserRole', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+        req = mockRequest();
+        res = mockResponse();
+        next = mockNext;
+        jest.clearAllMocks();
+    });
+
+    it('should successfully update a user role', async () => {
+        req.params.id = 'validUserId123';
+        req.body = {
+            name: 'Updated Name',
+            email: 'updated@example.com',
+            role: 'admin'
+        };
+
+        const mockUpdatedUser = {
+            _id: 'validUserId123',
+            name: 'Updated Name',
+            email: 'updated@example.com',
+            role: 'admin'
+        };
+
+        User.findByIdAndUpdate.mockResolvedValue(mockUpdatedUser);
+
+        await updateUserRole(req, res, next);
+
+        expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+            'validUserId123',
+            {
+                name: 'Updated Name',
+                email: 'updated@example.com',
+                role: 'admin'
+            },
+            {
+                new: true,
+                runValidators: true,
+            }
+        );
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+            success: true
+        });
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should call next with error if findByIdAndUpdate fails', async () => {
+        req.params.id = 'invalidUserId';
+        req.body = {
+            role: 'admin'
+        };
+
+        const mockError = new Error('Database Error');
+        User.findByIdAndUpdate.mockRejectedValue(mockError);
+
+        // await the promise returned by the catchAsyncErrors wrapper
+        await new Promise(resolve => {
+            updateUserRole(req, res, (...args) => {
+                next(...args);
+                resolve();
+            });
+        });
+
+        expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+            'invalidUserId',
+            {
+                name: undefined,
+                email: undefined,
+                role: 'admin'
+            },
+            {
+                new: true,
+                runValidators: true,
+            }
+        );
+
+        expect(next).toHaveBeenCalledWith(mockError);
+        expect(res.status).not.toHaveBeenCalled();
+        expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('should handle partial updates correctly', async () => {
+        req.params.id = 'validUserId123';
+        req.body = {
+            role: 'user'
+            // name and email missing
+        };
+
+        User.findByIdAndUpdate.mockResolvedValue({
+             _id: 'validUserId123',
+            role: 'user'
+        });
+
+        await updateUserRole(req, res, next);
+
+        expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+            'validUserId123',
+            {
+                name: undefined,
+                email: undefined,
+                role: 'user'
+            },
+            {
+                new: true,
+                runValidators: true,
+            }
+        );
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+            success: true
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds missing unit tests for the `updateUserRole` admin function in the `userController`. Previously, updating a user's role (or name/email via this admin endpoint) was completely untested, meaning critical bugs like incorrect database arguments or unhandled rejected promises could slip into production.

📊 **Coverage:** What scenarios are now tested
- The happy path: successfully updating a user's role (admin), name, and email via the API endpoint.
- Partial updates: correctly passing undefined values for fields that are not supplied, letting MongoDB handle only the fields present.
- Error handling: confirming that if `findByIdAndUpdate` throws an error (e.g., database unavailable or invalid ID format not caught earlier), the `catchAsyncErrors` middleware properly forwards the error to the Express `next` function.

✨ **Result:** The improvement in test coverage
We now have 3 focused, deterministic tests covering the `updateUserRole` controller method, ensuring reliable and secure admin operations. Testing relies on robust `jest.mock()` usage to stub MongoDB responses without triggering unneeded downstream services like Cloudinary.

---
*PR created automatically by Jules for task [15302530539077626954](https://jules.google.com/task/15302530539077626954) started by @parilsanghvi*