### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hashed password leak in authentication endpoints

### DIFF
--- a/backend/tests/jwtToken_security.test.js
+++ b/backend/tests/jwtToken_security.test.js
@@ -1,0 +1,67 @@
+const sendToken = require('../utils/jwtToken');
+
+describe('JWT Token Security Verification', () => {
+    let mockRes;
+    let mockCookie;
+    let mockJson;
+    let mockStatus;
+
+    beforeEach(() => {
+        // Mock the Express response object correctly
+        mockJson = jest.fn();
+        mockCookie = jest.fn().mockReturnValue({ json: mockJson });
+        mockStatus = jest.fn().mockReturnValue({ cookie: mockCookie });
+        mockRes = { status: mockStatus };
+
+        process.env.COOKIE_EXPIRE = '7';
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should not leak the user password in the json response', () => {
+        const mockUser = {
+            _id: '12345',
+            name: 'John Doe',
+            email: 'john@example.com',
+            password: 'hashedpassword123',
+            getJWTToken: jest.fn().mockReturnValue('mocked-token-string')
+        };
+
+        // Call the function
+        sendToken(mockUser, 200, mockRes);
+
+        // Verify that res.status().cookie().json() was called correctly
+        expect(mockStatus).toHaveBeenCalledWith(200);
+        expect(mockCookie).toHaveBeenCalledWith('token', 'mocked-token-string', expect.any(Object));
+        expect(mockJson).toHaveBeenCalledTimes(1);
+
+        const responsePayload = mockJson.mock.calls[0][0];
+
+        // Assert success and basic user properties are present
+        expect(responsePayload.success).toBe(true);
+        expect(responsePayload.user).toBeDefined();
+        expect(responsePayload.user._id).toBe('12345');
+        expect(responsePayload.user.name).toBe('John Doe');
+
+        // Security check: Assert that the password has been stripped out
+        expect(responsePayload.user.password).toBeUndefined();
+    });
+
+    it('should work fine if user object has no password field', () => {
+        const mockUser = {
+            _id: '67890',
+            name: 'Jane Smith',
+            email: 'jane@example.com',
+            getJWTToken: jest.fn().mockReturnValue('another-token')
+        };
+
+        sendToken(mockUser, 200, mockRes);
+
+        const responsePayload = mockJson.mock.calls[0][0];
+        expect(responsePayload.success).toBe(true);
+        expect(responsePayload.user._id).toBe('67890');
+        expect(responsePayload.user.password).toBeUndefined();
+    });
+});

--- a/backend/utils/jwtToken.js
+++ b/backend/utils/jwtToken.js
@@ -10,6 +10,13 @@ const sendToken = (user, statusCode, res) => {
         secure: process.env.NODE_ENV === 'PRODUCTION' || process.env.NODE_ENV === 'production',
         sameSite: 'strict',
     }
+
+    // Security Fix: Prevent leaking hashed password when user object is passed
+    // explicitly via .select("+password") in the controller (e.g. login, updatePassword)
+    if (user && user.password) {
+        user.password = undefined;
+    }
+
     res.status(statusCode).cookie("token",token,options).json({
         success:true,
         user,


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Information Exposure - When authenticating users (e.g., login or update password), the backend explicitly fetched the user's document along with their hashed password (`.select("+password")`) to verify credentials. The entire user document, including the hashed password, was then passed to `sendToken()`, which subsequently included it in the final `res.json()` API payload to the frontend.
🎯 **Impact**: Anyone successfully authenticating would receive their hashed password in the API response. While they already know their plaintext password, leaking password hashes facilitates offline cracking attempts and exposes the hashing algorithm structure, weakening the overall security posture and violating data minimization principles.
🔧 **Fix**: Modified `backend/utils/jwtToken.js` to explicitly strip the `password` field from the user object (e.g., `user.password = undefined;`) immediately prior to JSON serialization.
✅ **Verification**: Created and successfully ran a dedicated Jest unit test (`backend/tests/jwtToken_security.test.js`) that explicitly verifies the password property is completely omitted from the resulting payload. Ran the full backend test suite (`npm run test:backend`) to ensure no regressions.

---
*PR created automatically by Jules for task [15355100465406383543](https://jules.google.com/task/15355100465406383543) started by @parilsanghvi*