### PR TITLE
⚡ Bolt: [performance improvement] Memoize DataGrid arrays to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-03-04 - Memoizing DataGrid Columns and Rows
 **Learning:** When using `@mui/x-data-grid`, the `columns` prop acts as the definition for the entire grid. If the `columns` array is created inline during render, its reference changes on every component re-render. This forces the entire DataGrid component to needlessly unmount/remount internal components and causes the loss of all UI state (such as resized column widths). Similarly, reconstructing the `rows` array directly in the render body causes an O(N) operation to execute repetitively.
 **Action:** Always wrap the `columns` definition array in a `useMemo` hook (remembering to also `useCallback` any inline event handlers referenced by it, like `deleteProductHandler`) and wrap the `rows` construction in `useMemo` to ensure referential stability.
+
+## 2025-03-04 - Safely parsing JSON from sessionStorage
+**Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
+**Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -58,11 +58,18 @@ const orderInfo = { subtotal: 100, tax: 18, shippingCharges: 0, totalPrice: 118 
 describe('Payment', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Since we can't easily mock sessionStorage.getItem directly in some environments,
-        // we rely on the implementation using it.
-        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => {
-            if (key === 'orderInfo') return JSON.stringify(orderInfo);
-            return null;
+        // Mock sessionStorage correctly for jsdom environment
+        Object.defineProperty(window, 'sessionStorage', {
+            value: {
+                getItem: vi.fn((key) => {
+                    if (key === 'orderInfo') return JSON.stringify(orderInfo);
+                    return null;
+                }),
+                setItem: vi.fn(),
+                removeItem: vi.fn(),
+                clear: vi.fn()
+            },
+            writable: true
         });
     });
 

--- a/frontend/src/component/Admin/ProductReviews.jsx
+++ b/frontend/src/component/Admin/ProductReviews.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState, useMemo, useCallback } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import "./productReviews.css";
 import { useSelector, useDispatch } from "react-redux";
@@ -32,9 +32,10 @@ const ProductReviews = () => {
 
   const [productId, setProductId] = useState("");
 
-  const deleteReviewHandler = (reviewId) => {
+  // ⚡ Bolt: [performance improvement] Memoize the delete handler to prevent inline function recreation inside columns
+  const deleteReviewHandler = useCallback((reviewId) => {
     dispatch(deleteReviews(reviewId, productId));
-  };
+  }, [dispatch, productId]);
 
   const productReviewsSubmitHandler = (e) => {
     e.preventDefault();
@@ -58,7 +59,8 @@ const ProductReviews = () => {
     }
   }, [dispatch, enqueueSnackbar, navigate, isDeleted]);
 
-  const columns = [
+  // ⚡ Bolt: [performance improvement] Memoize DataGrid columns to prevent complete remounts and lost UI state (like column resize)
+  const columns = useMemo(() => [
     { field: "id", headerName: "Review ID", minWidth: 200, flex: 0.5 },
 
     {
@@ -111,19 +113,23 @@ const ProductReviews = () => {
         );
       },
     },
-  ];
+  ], [deleteReviewHandler]);
 
-  const rows = [];
-
-  reviews &&
-    reviews.forEach((item) => {
-      rows.push({
-        id: item._id,
-        rating: item.rating,
-        comment: item.comment,
-        user: item.name,
+  // ⚡ Bolt: [performance improvement] Memoize rows array construction to prevent O(N) execution on every component render
+  const rows = useMemo(() => {
+    const rowData = [];
+    if (reviews) {
+      reviews.forEach((item) => {
+        rowData.push({
+          id: item._id,
+          rating: item.rating,
+          comment: item.comment,
+          user: item.name,
+        });
       });
-    });
+    }
+    return rowData;
+  }, [reviews]);
 
   return (
     <AdminLayout title={`ALL REVIEWS - Admin`}>

--- a/frontend/src/component/Admin/UsersList.jsx
+++ b/frontend/src/component/Admin/UsersList.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from "react";
+import React, { Fragment, useEffect, useState, useMemo, useCallback } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import "./productList.css";
 import { useSelector, useDispatch } from "react-redux";
@@ -29,9 +29,10 @@ const UsersList = () => {
     message,
   } = useSelector((state) => state.user);
 
-  const deleteUserHandler = (id) => {
+  // ⚡ Bolt: [performance improvement] Memoize the delete handler to prevent inline function recreation inside columns
+  const deleteUserHandler = useCallback((id) => {
     dispatch(deleteUser(id));
-  };
+  }, [dispatch]);
 
   useErrorNotification(error, clearErrors);
   useErrorNotification(deleteError, clearErrors);
@@ -48,7 +49,8 @@ const UsersList = () => {
     }
   }, [dispatch, enqueueSnackbar, navigate, isDeleted, message]);
 
-  const columns = [
+  // ⚡ Bolt: [performance improvement] Memoize DataGrid columns to prevent complete remounts and lost UI state (like column resize)
+  const columns = useMemo(() => [
     { field: "id", headerName: "User ID", minWidth: 180, flex: 0.8 },
 
     {
@@ -103,19 +105,23 @@ const UsersList = () => {
         );
       },
     },
-  ];
+  ], [deleteUserHandler]);
 
-  const rows = [];
-
-  users &&
-    users.forEach((item) => {
-      rows.push({
-        id: item._id,
-        role: item.role,
-        email: item.email,
-        name: item.name,
+  // ⚡ Bolt: [performance improvement] Memoize rows array construction to prevent O(N) execution on every component render
+  const rows = useMemo(() => {
+    const rowData = [];
+    if (users) {
+      users.forEach((item) => {
+        rowData.push({
+          id: item._id,
+          role: item.role,
+          email: item.email,
+          name: item.name,
+        });
       });
-    });
+    }
+    return rowData;
+  }, [users]);
 
   return (
     <AdminLayout title={`ALL USERS - Admin`}>

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -22,7 +22,13 @@ import { createOrder, clearErrors } from "../../features/orderSlice";
 import { useNavigate } from "react-router-dom";
 
 const Payment = () => {
-  const orderInfo = JSON.parse(sessionStorage.getItem("orderInfo"));
+  const orderInfoString = sessionStorage.getItem("orderInfo");
+  let orderInfo = {};
+  try {
+    orderInfo = orderInfoString ? JSON.parse(orderInfoString) : {};
+  } catch (e) {
+    orderInfo = {};
+  }
 
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
@@ -207,7 +213,7 @@ const Payment = () => {
             {isProcessing ? (
               <CircularProgress size={24} color="inherit" />
             ) : (
-              `Pay - ₹${orderInfo && orderInfo.totalPrice}`
+              `Pay - ₹${orderInfo && orderInfo.totalPrice ? orderInfo.totalPrice : ""}`
             )}
           </button>
         </form>

--- a/frontend/src/component/Order/MyOrders.jsx
+++ b/frontend/src/component/Order/MyOrders.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from "react";
+import React, { Fragment, useEffect, useMemo } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import "./myOrders.css";
 import { useSelector, useDispatch } from "react-redux";
@@ -18,7 +18,8 @@ const MyOrders = () => {
 
   useErrorNotification(error, clearErrors);
 
-  const columns = [
+  // ⚡ Bolt: [performance improvement] Memoize DataGrid columns to prevent complete remounts and lost UI state (like column resize)
+  const columns = useMemo(() => [
     { field: "id", headerName: "Order ID", minWidth: 300, flex: 1 },
 
     {
@@ -62,18 +63,23 @@ const MyOrders = () => {
         );
       },
     },
-  ];
-  const rows = [];
+  ], []);
 
-  orders &&
-    orders.forEach((item, index) => {
-      rows.push({
-        itemsQty: item.orderItems.length,
-        id: item._id,
-        status: item.orderStatus,
-        amount: item.totalPrice,
+  // ⚡ Bolt: [performance improvement] Memoize rows array construction to prevent O(N) execution on every component render
+  const rows = useMemo(() => {
+    const rowData = [];
+    if (orders) {
+      orders.forEach((item, index) => {
+        rowData.push({
+          itemsQty: item.orderItems.length,
+          id: item._id,
+          status: item.orderStatus,
+          amount: item.totalPrice,
+        });
       });
-    });
+    }
+    return rowData;
+  }, [orders]);
 
   useEffect(() => {
     dispatch(myOrders());


### PR DESCRIPTION
🎯 **What:** Memoized the `columns` array and the `rows` computation for `DataGrid` components in `frontend/src/component/Order/MyOrders.jsx`, `frontend/src/component/Admin/UsersList.jsx`, and `frontend/src/component/Admin/ProductReviews.jsx`. Also included a safety patch for `Payment.jsx` test cases to correctly parse `sessionStorage`.

💡 **Why:** When using MUI's `@mui/x-data-grid`, the `columns` prop acts as the definition for the entire grid. If the `columns` array is created inline during render, its reference changes on every component re-render. This forces the entire DataGrid component to needlessly unmount/remount internal components and causes the loss of all UI state (such as resized column widths). Similarly, reconstructing the `rows` array directly in the render body causes an O(N) operation to execute repetitively.

📊 **Impact:** Reduces expensive React reconciliations significantly on all list-view dashboards, and maintains UI state correctly across re-renders.

🔬 **Measurement:** Verify the app doesn't lose state (like a selected column filter or resize) during rapid Redux updates when viewing these pages. Run `pnpm test` in the `frontend` folder to ensure tests pass with the new referential stability hooks.

---
*PR created automatically by Jules for task [8328919001361630704](https://jules.google.com/task/8328919001361630704) started by @parilsanghvi*