### PR TITLE
🎨 Palette: Fix dynamic button accessible name override

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+## 2024-05-28 - Fix dynamic button accessible name override
+**Learning:** Avoid applying static `aria-label` attributes to buttons containing dynamic, contextually important text (e.g., 'Pay - ₹110'). A static `aria-label` completely overrides the element's visible text for screen readers, masking essential contextual information.
+**Action:** Use `aria-label` conditionally (e.g., `aria-label={isProcessing ? "Processing payment" : undefined}`) or rely on native text content to ensure dynamic information is accessible.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,14 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
-        expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
+        expect(button).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -207,7 +207,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 **What:** Modified the `aria-label` on the Payment component's submit button so that it is conditionally set to `undefined` when not processing, rather than a static "Pay now".
🎯 **Why:** To prevent the static `aria-label` from overriding and masking the dynamic, contextually important text (e.g., "Pay - ₹110") for screen reader users, ensuring they hear the actual charge amount.
📸 **Before/After:** Not applicable (non-visual change).
♿ **Accessibility:** Yes! Improved the accessible name computation for screen readers on a critical action button.

---
*PR created automatically by Jules for task [158055981038772803](https://jules.google.com/task/158055981038772803) started by @parilsanghvi*