### PR TITLE
⚡ Bolt: [performance improvement] getAdminProducts optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+
+## 2025-03-05 - [Optimize Document Counting]
+**Learning:** For unfiltered counts in Mongoose (e.g. counting all items in a collection for an admin panel), `estimatedDocumentCount()` is significantly faster (O(1) time complexity using collection metadata) compared to `countDocuments()` which performs a full collection scan (O(N)). Also, independent queries like total count and paginated data fetch can be parallelized using `Promise.all` to reduce total request latency.
+**Action:** When calculating total unfiltered documents, consistently use `Model.estimatedDocumentCount()`, and always parallelize independent database queries in controllers.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: Use estimatedDocumentCount() for O(1) counting instead of full collection scan
+    const totalCountPromise = Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 
@@ -108,7 +109,11 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
         query = query.skip(skip).limit(limit);
     }
 
-    const products = await query;
+    // ⚡ Bolt: Parallelize independent queries to reduce total latency
+    const [totalCount, products] = await Promise.all([
+        totalCountPromise,
+        query
+    ]);
 
     res.status(200).json({
         success: true,


### PR DESCRIPTION
💡 **What:** 
- Replaced the unfiltered `Product.countDocuments()` call with `Product.estimatedDocumentCount()` inside the `getAdminProducts` controller.
- Parallelized the newly created `estimatedDocumentCount()` promise with the paginated `Product.find()` query using `Promise.all`.

🎯 **Why:** 
- `countDocuments()` requires MongoDB to perform a full O(N) index scan, which becomes increasingly slow as the total number of products grows. Since the admin panel is simply fetching the total number of documents (no filters applied to the count query), `estimatedDocumentCount()` provides the identical answer in O(1) time by reading collection metadata.
- Previously, the controller awaited the count query before even initiating the main data query. Wrapping independent asynchronous queries inside `Promise.all` allows them to execute concurrently, directly reducing the total latency of the API endpoint.

📊 **Impact:** 
- Significant reduction in database load and response latency for the admin products list. As the number of products scales, this single query changes from an O(N) operation to O(1), and concurrent execution provides further latency savings for the overall response.

🔬 **Measurement:** 
- Can be measured via existing backend test suite (`pnpm test:backend`), specifically the tests associated with the `getAdminProducts` controller and `product_admin_pagination_benchmark.test.js`, confirming the logic remains fully intact while delivering the products quicker.

---
*PR created automatically by Jules for task [4988105893788783692](https://jules.google.com/task/4988105893788783692) started by @parilsanghvi*