### PR TITLE
🎨 Palette: Fix Payment button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,7 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+
+## 2025-05-27 - Dynamic Aria-Label Overriding Visible Text
+**Learning:** Adding a static `aria-label` attribute (e.g., "Pay now") to a button that displays dynamically generated contextual text (e.g., "Pay - ₹110") causes screen readers to completely ignore the valuable visible text. This masks essential context.
+**Action:** Remove static `aria-labels` when the button's visible text already conveys the purpose effectively. Only use `aria-label` conditionally when necessary, such as replacing the button text with "Processing payment" while a loading spinner replaces the visible text.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,14 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pay - ₹118/i })).toBeInTheDocument();
         expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -169,7 +169,9 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) {
+        payBtn.current.disabled = false;
+      }
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };
@@ -207,7 +209,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 What: Removed the static `aria-label="Pay now"` from the `Payment.jsx` submit button when it is not in a processing state.
🎯 Why: A static `aria-label` completely overrides the element's visible text for screen readers. By having `aria-label="Pay now"`, screen reader users were completely missing out on the dynamically generated contextual text (e.g., "Pay - ₹118"), stripping them of essential information regarding the transaction amount.
📸 Before/After: N/A (Non-visual accessibility change)
♿ Accessibility: Ensures that screen readers can accurately convey the dynamic transaction amount embedded in the button's native text content instead of a generic "Pay now" fallback.

---
*PR created automatically by Jules for task [1859539836484119097](https://jules.google.com/task/1859539836484119097) started by @parilsanghvi*