### PR TITLE
🎨 Palette: [UX improvement] Fix aria-label override on Payment button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,6 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+## 2026-04-04 - Fix aria-label masking contextual button text
+**Learning:** Applying static `aria-label` attributes to buttons with dynamic, contextually important text (like a total price in a checkout button) completely overrides the element's visible text for screen readers, masking essential information.
+**Action:** Use `aria-label` conditionally (e.g., only during loading states) or let screen readers rely on native text content to preserve context.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,14 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pay - ₹118/i })).toBeInTheDocument();
         expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -169,7 +169,9 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) {
+        payBtn.current.disabled = false;
+      }
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -207,7 +207,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 **What:** Modified the `aria-label` on the Payment button to be applied conditionally only when the button is in the loading state (`isProcessing`), and `undefined` otherwise. Updated corresponding frontend tests to reflect the new accessible name.

🎯 **Why:** The button's visible text includes the total amount ("Pay - ₹[Amount]"), but the static `aria-label="Pay now"` completely overrode this for screen readers. This masked essential contextual information (the amount being charged) from assistive technologies.

📸 **Before/After:**
- **Before:** Screen readers announce "Pay now button".
- **After:** Screen readers announce "Pay - ₹[Amount] button".

♿ **Accessibility:** Fixes a WCAG violation where the accessible name of the button did not match or contain its visible text, ensuring parity of information for sighted and non-sighted users.

---
*PR created automatically by Jules for task [6884460426425629593](https://jules.google.com/task/6884460426425629593) started by @parilsanghvi*