### PR TITLE
🎨 Palette: Fix Payment Button Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,6 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+## 2024-05-19 - Fix Payment Button Accessibility
+**Learning:** A static `aria-label` completely overrides the element's visible text content for screen readers. Using `aria-label="Pay now"` on a button containing dynamic text like `Pay - ₹118` prevents users from hearing the payment amount.
+**Action:** Use `aria-label` conditionally (e.g. `isProcessing ? "Processing payment" : undefined`) to allow native text content to be announced when it contains contextually important, dynamic information. Ensure tests assert against the dynamically exposed visible text.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,13 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
-        expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Pay - ₹118/i })).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /Pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -99,7 +99,9 @@ const Payment = () => {
     e.preventDefault();
 
     setIsProcessing(true);
-    payBtn.current.disabled = true;
+    if (payBtn.current) {
+      payBtn.current.disabled = true;
+    }
     setIsProcessing(true);
 
     try {
@@ -118,7 +120,9 @@ const Payment = () => {
 
       if (!stripe || !elements) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) {
+          payBtn.current.disabled = false;
+        }
         return;
       }
 
@@ -141,7 +145,9 @@ const Payment = () => {
 
       if (result.error) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) {
+          payBtn.current.disabled = false;
+        }
         setIsProcessing(false);
 
         enqueueSnackbar(result.error.message, { variant: "error" });
@@ -161,7 +167,9 @@ const Payment = () => {
           navigate("/success");
         } else {
           setIsProcessing(false);
-          payBtn.current.disabled = false;
+          if (payBtn.current) {
+            payBtn.current.disabled = false;
+          }
           enqueueSnackbar("There's some issue while processing payment ", {
             variant: "error",
           });
@@ -169,7 +177,9 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) {
+        payBtn.current.disabled = false;
+      }
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -207,7 +207,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 **What:** Removed the static `aria-label="Pay now"` from the payment button and made it conditional (`isProcessing ? "Processing payment" : undefined`), allowing the button's dynamic text content to be announced by screen readers when not processing. Updated test cases to reflect the accessible name change.

🎯 **Why:** The static `aria-label` completely overrode the button's visible text (e.g., `Pay - ₹118`), preventing screen reader users from hearing the contextually important payment amount.

📸 **Before/After:** The button visually remains identical, but its accessible name changes dynamically, exposing the transaction total appropriately.

♿ **Accessibility:** Fixes a WCAG 2.5.3 (Label in Name) violation by ensuring the accessible name matches the visible text when not in a loading state.

---
*PR created automatically by Jules for task [8890387522075559844](https://jules.google.com/task/8890387522075559844) started by @parilsanghvi*