### PR TITLE
🎨 Palette: [UX improvement] Expose dynamic price to screen readers on Payment button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,6 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+## 2024-04-12 - Dynamic Text vs Static ARIA Labels
+**Learning:** Applying a static `aria-label` to a button containing dynamic, contextually important text (e.g., 'Pay - ₹118') completely overrides the element's visible text for screen readers, masking essential contextual information.
+**Action:** Avoid static `aria-label` overrides on elements with dynamic content; set `aria-label` conditionally (e.g., to undefined) to expose the native text content.

--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,14 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pay - ₹118/i })).toBeInTheDocument();
         expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -99,7 +99,7 @@ const Payment = () => {
     e.preventDefault();
 
     setIsProcessing(true);
-    payBtn.current.disabled = true;
+    if (payBtn.current) payBtn.current.disabled = true;
     setIsProcessing(true);
 
     try {
@@ -118,7 +118,7 @@ const Payment = () => {
 
       if (!stripe || !elements) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         return;
       }
 
@@ -141,7 +141,7 @@ const Payment = () => {
 
       if (result.error) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         setIsProcessing(false);
 
         enqueueSnackbar(result.error.message, { variant: "error" });
@@ -161,7 +161,7 @@ const Payment = () => {
           navigate("/success");
         } else {
           setIsProcessing(false);
-          payBtn.current.disabled = false;
+          if (payBtn.current) payBtn.current.disabled = false;
           enqueueSnackbar("There's some issue while processing payment ", {
             variant: "error",
           });
@@ -169,7 +169,7 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) payBtn.current.disabled = false;
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };
@@ -207,7 +207,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 **What:** Conditionally removed the static `aria-label` ("Pay now") on the Payment screen's submit button when not in a loading state, and added defensive null-checks for DOM ref manipulation (`payBtn.current`).

🎯 **Why:** A static `aria-label` completely overrides the element's dynamic visible text for screen readers. By removing the static override, screen readers will now announce the dynamic, contextually important text ("Pay - ₹118"), providing the user with explicit context of the charge amount before submission. The null checks prevent runtime `TypeError`s if the component unmounts quickly or is mocked heavily in testing environments.

📸 **Before/After:** No visual changes. Screen readers will read "Pay - ₹118" instead of "Pay now".

♿ **Accessibility:** Solves a major context-loss issue for screen reader users on a critical payment boundary.

---
*PR created automatically by Jules for task [9071372435154550621](https://jules.google.com/task/9071372435154550621) started by @parilsanghvi*