### PR TITLE
🎨 Palette: Fix dynamic button accessible name override in Payment form

### DIFF
--- a/frontend/src/__tests__/components/Payment.test.jsx
+++ b/frontend/src/__tests__/components/Payment.test.jsx
@@ -87,14 +87,14 @@ describe('Payment', () => {
 
     it('renders pay button with total price', () => {
         render(<Payment />);
-        expect(screen.getByRole('button', { name: /pay now/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pay - ₹118/i })).toBeInTheDocument();
         expect(screen.getByText('Pay - ₹118')).toBeInTheDocument();
     });
 
     it('shows loading state on submit', async () => {
         axios.post.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ data: { client_secret: '123' } }), 100)));
         render(<Payment />);
-        const button = screen.getByRole('button', { name: /pay now/i });
+        const button = screen.getByRole('button', { name: /pay - ₹118/i });
         fireEvent.click(button);
         
         // The button should now be disabled and show the CircularProgress.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -118,7 +118,7 @@ const Payment = () => {
 
       if (!stripe || !elements) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         return;
       }
 
@@ -141,7 +141,7 @@ const Payment = () => {
 
       if (result.error) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         setIsProcessing(false);
 
         enqueueSnackbar(result.error.message, { variant: "error" });
@@ -161,7 +161,7 @@ const Payment = () => {
           navigate("/success");
         } else {
           setIsProcessing(false);
-          payBtn.current.disabled = false;
+          if (payBtn.current) payBtn.current.disabled = false;
           enqueueSnackbar("There's some issue while processing payment ", {
             variant: "error",
           });
@@ -169,7 +169,7 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) payBtn.current.disabled = false;
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };
@@ -207,7 +207,7 @@ const Payment = () => {
             className="primary-btn paymentFormBtn"
             disabled={isProcessing}
             aria-busy={isProcessing}
-            aria-label={isProcessing ? "Processing payment" : "Pay now"}
+            aria-label={isProcessing ? "Processing payment" : undefined}
             style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: "10px" }}
           >
             {isProcessing ? (


### PR DESCRIPTION
💡 **What:** Modified `aria-label` conditional logic on the Stripe "Pay" button to be `undefined` instead of a static "Pay now" string when the component is not in a processing state. Also updated the corresponding Vitest test so it asserts against the native, visible button text (`Pay - ₹118`).
🎯 **Why:** Static `aria-label`s take priority in the accessibility tree and completely mask native text content for screen readers. Using `aria-label="Pay now"` prevented visually impaired users from hearing the contextual order total amount embedded natively in the button text.
📸 **Before/After:** The button visually looks the same. Before, a screen reader would dictate "Pay now, Button." Now, it correctly dictates "Pay - ₹[total price], Button." 
♿ **Accessibility:** Fixes a WCAG 2.1 "Label in Name" violation that impacts screen reader and voice control users.

---
*PR created automatically by Jules for task [592933777968941875](https://jules.google.com/task/592933777968941875) started by @parilsanghvi*