### PR TITLE
⚡ Bolt: Optimize total product count retrieval for admin

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+## 2026-04-25 - Optimize Collection Counting
+**Learning:** Using `countDocuments()` without filters forces an O(N) collection scan. For total document counts without filters, Mongoose's `estimatedDocumentCount()` leverages collection metadata for an O(1) operation.
+**Action:** Always prefer `estimatedDocumentCount()` over `countDocuments()` when counting all documents in a collection without any query conditions.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,11 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt Optimization
+    // What: Replaced countDocuments() with estimatedDocumentCount()
+    // Why: countDocuments() performs an O(N) full collection scan without filters.
+    // Impact: estimatedDocumentCount() uses collection metadata, providing an O(1) operation for significantly faster total counts.
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `countDocuments()` with `estimatedDocumentCount()` for fetching the total product count in the `getAdminProducts` controller.
🎯 Why: Calling `countDocuments()` without query filters executes a costly O(N) full collection scan. For scenarios that only need the global document count, `estimatedDocumentCount()` uses collection metadata for a fast O(1) retrieval.
📊 Impact: Expected to reduce CPU overhead and latency significantly when counting large collections in the Admin Products view.
🔬 Measurement: Observe lower database execution times and reduced payload latency via APM or MongoDB slow query logs when the admin dashboard products endpoint is hit.

---
*PR created automatically by Jules for task [11928322968969737799](https://jules.google.com/task/11928322968969737799) started by @parilsanghvi*