### PR TITLE
🎨 Palette: Add password visibility toggle to reset password form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+## 2026-04-28 - Add password visibility toggle to ResetPassword form
+**Learning:** Adding interactive elements (like visibility toggles) into standard form fields requires explicitly wrapping them in a semantic `<button type="button">` element and managing their absolute positioning securely within a `position: relative` wrapper, ensuring padding on the input avoids overlap.
+**Action:** Always include a show/hide password feature for password inputs across all authentication forms (e.g., login, signup, reset password) to prevent users from getting locked out due to unseen typos, and consistently style them using shared classes like `.password-toggle-btn`.

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,10 +44,12 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -85,6 +87,24 @@
 
 .resetPasswordBtn:hover {
   background-color: var(--color-secondary);
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 @media screen and (max-width: 600px) {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,39 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input
+                    type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input
+                    type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added a show/hide password toggle to the "New Password" and "Confirm Password" inputs on the Reset Password page.
🎯 Why: This helps users ensure they are typing their new password correctly without typos, which is especially important during a password reset flow to prevent getting locked out.
📸 Before/After: Visual toggle button added to the right side of the password inputs, matching the existing design pattern used in the Update Password component.
♿ Accessibility: The toggles use native `<button type="button">` elements ensuring they are keyboard-navigable, and include dynamic `aria-label` attributes to explicitly indicate whether the action will show or hide the password for screen reader users.

---
*PR created automatically by Jules for task [5075201921274166340](https://jules.google.com/task/5075201921274166340) started by @parilsanghvi*