### PR TITLE
🎨 Palette: Add show/hide password toggle to ResetPassword form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,4 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+## 2026-04-30 - Added Show/Hide Password Toggle to ResetPassword Form\n**Learning:** The ResetPassword component was missing the visibility toggles that were already implemented in other authentication forms (like LoginSignup and UpdatePassword), creating an inconsistent and less accessible experience for users attempting to recover their accounts.\n**Action:** Always ensure critical authentication components share consistent UX patterns, specifically providing show/hide password toggles on all password input fields to prevent typos and lockouts.

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,10 +44,12 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -67,6 +69,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,37 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide new password" : "Show new password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added a show/hide password visibility toggle to both the "New Password" and "Confirm Password" fields in the `ResetPassword` component.
🎯 Why: Users frequently make typos during password resets, which can lead to locked accounts or frustration. Providing a visibility toggle is a standard UX best practice that improves confidence and accessibility.
📸 Before/After: Implemented visually matching toggles (using Material UI icons) as seen in other auth components like `LoginSignup` and `UpdatePassword`.
♿ Accessibility: Included dynamic `aria-label`s ("Show new password" / "Hide new password") to ensure screen reader users are aware of the button's purpose and state.

---
*PR created automatically by Jules for task [15266736536870346685](https://jules.google.com/task/15266736536870346685) started by @parilsanghvi*