### PR TITLE
⚡ Bolt: [performance improvement] Optimize admin product counting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+
+## 2025-03-05 - countDocuments() vs estimatedDocumentCount()
+**Learning:** Using `Model.countDocuments()` without filters executes an O(N) full collection scan, which severely degrades performance on large datasets.
+**Action:** Always prefer `Model.estimatedDocumentCount()` for O(1) retrieval using collection metadata when counting all documents in a collection where exact, filtered counts are unnecessary.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,11 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: Performance Optimization
+    // What: Replaced countDocuments() with estimatedDocumentCount()
+    // Why: countDocuments() without filters causes an O(N) full collection scan.
+    // Impact: estimatedDocumentCount() resolves in O(1) time using collection metadata, making it significantly faster for large collections.
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `await Product.countDocuments()` with `await Product.estimatedDocumentCount()` in the `getAdminProducts` controller.
🎯 Why: Calling `countDocuments()` without any query filters forces MongoDB to perform a full collection scan (or index scan), which is an O(N) operation that degrades linearly as the collection size grows. `estimatedDocumentCount()` retrieves the count directly from collection metadata in O(1) time.
📊 Impact: Significantly faster execution time for counting all documents in the collection, reducing the time complexity of the operation from O(N) to O(1) for large collections.
🔬 Measurement: Verified through the backend test suite, particularly `backend/tests/integration/product_admin_pagination_benchmark.test.js`, confirming functional correctness while improving raw query performance.

---
*PR created automatically by Jules for task [3901297518865089584](https://jules.google.com/task/3901297518865089584) started by @parilsanghvi*