### PR TITLE
⚡ Bolt: [performance improvement] Memoize country and state lists in Shipping component

### DIFF
--- a/frontend/src/component/Cart/Shipping.jsx
+++ b/frontend/src/component/Cart/Shipping.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useState, useMemo } from "react";
 import "./Shipping.css";
 import { useSelector, useDispatch } from "react-redux";
 import { saveShippingInfo } from "../../features/cartSlice";
@@ -26,6 +26,14 @@ const Shipping = () => {
   const [country, setCountry] = useState(shippingInfo.country);
   const [pinCode, setPinCode] = useState(shippingInfo.pinCode);
   const [phoneNo, setPhoneNo] = useState(shippingInfo.phoneNo);
+
+  const countriesList = useMemo(() => {
+    return Country ? Country.getAllCountries() : [];
+  }, []);
+
+  const statesList = useMemo(() => {
+    return country && State ? State.getStatesOfCountry(country) : [];
+  }, [country]);
 
   const shippingSubmit = (e) => {
     e.preventDefault();
@@ -114,12 +122,11 @@ const Shipping = () => {
                 onChange={(e) => setCountry(e.target.value)}
               >
                 <option value="">Country</option>
-                {Country &&
-                  Country.getAllCountries().map((item) => (
-                    <option key={item.isoCode} value={item.isoCode}>
-                      {item.name}
-                    </option>
-                  ))}
+                {countriesList.map((item) => (
+                  <option key={item.isoCode} value={item.isoCode}>
+                    {item.name}
+                  </option>
+                ))}
               </select>
             </div>
 
@@ -134,12 +141,11 @@ const Shipping = () => {
                   onChange={(e) => setState(e.target.value)}
                 >
                   <option value="">State</option>
-                  {State &&
-                    State.getStatesOfCountry(country).map((item) => (
-                      <option key={item.isoCode} value={item.isoCode}>
-                        {item.name}
-                      </option>
-                    ))}
+                  {statesList.map((item) => (
+                    <option key={item.isoCode} value={item.isoCode}>
+                      {item.name}
+                    </option>
+                  ))}
                 </select>
               </div>
             )}


### PR DESCRIPTION
💡 **What:** Wrapped `Country.getAllCountries()` and `State.getStatesOfCountry()` calls inside the `Shipping` component in `useMemo` hooks.
🎯 **Why:** The `Shipping` component holds multiple controlled form inputs (address, phone number, pin code, etc.) that update local component state on every single keystroke. Before this change, the heavy synchronous arrays returned by the `country-state-city` library were recalculated on every render, causing input lag. Memoizing these lists prevents redundant O(N) calculations and stabilizes object references across renders.
📊 **Impact:** Significantly reduces CPU overhead during form interaction, preventing the component from stalling when users type their shipping details.
🔬 **Measurement:** Verify by typing rapidly into the "Address" or "Phone Number" inputs; notice the improved responsiveness compared to the previous state. Also validated by running the existing test suite (`pnpm test`) which confirms no functional regressions.

---
*PR created automatically by Jules for task [3280011717123729159](https://jules.google.com/task/3280011717123729159) started by @parilsanghvi*