### PR TITLE
⚡ Bolt: [performance improvement] Optimize global product count retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+
+## 2025-03-05 - Avoid Full Collection Scans for Global Counts
+**Learning:** Using `Model.countDocuments()` without filters executes an O(N) full collection scan, which scales poorly as the database grows. In `backend/controllers/productController.js` and similar global listings, this created an unnecessary bottleneck for paginated admin responses.
+**Action:** Replace `Model.countDocuments()` with `Model.estimatedDocumentCount()` whenever counting all documents in a collection. This performs an O(1) metadata read, significantly speeding up paginated requests over large datasets.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // Optimized: Use estimatedDocumentCount() for O(1) counting instead of O(N) full collection scan
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `await Product.countDocuments()` with `await Product.estimatedDocumentCount()` inside the `getAdminProducts` controller.
🎯 Why: `countDocuments` with an empty filter performs an O(N) full collection scan. When listing products for the admin panel, the total count should be retrieved from MongoDB collection metadata in O(1) time using `estimatedDocumentCount`.
📊 Impact: Expected to significantly reduce query time for `getAdminProducts` in large datasets, avoiding a full table scan and reducing overall response latency.
🔬 Measurement: Verify using backend performance tests (`pnpm test:backend backend/tests/integration/product_admin_pagination_benchmark.test.js`), which should confirm the O(1) optimization.

---
*PR created automatically by Jules for task [12799570433859614492](https://jules.google.com/task/12799570433859614492) started by @parilsanghvi*