### PR TITLE
🎨 Palette: Add password visibility toggles to Reset Password form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+
+## 2024-05-18 - Add password visibility toggles to authentication forms
+**Learning:** Authentication forms with multiple password fields (like Reset Password or Update Password) frequently omit visibility toggles for the secondary fields (e.g., "Confirm Password"), forcing users to guess if they made a typo. This is particularly problematic for users relying on screen readers or those with cognitive disabilities.
+**Action:** Always provide functional password visibility toggles (with clear `aria-label`s) for *all* password inputs within a form, not just the primary one, to ensure a consistent and accessible user experience. Ensure they are styled appropriately and do not overlap with the input text.

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,11 +44,14 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
+  height: 50px;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
   border-radius: 0;
@@ -67,6 +70,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,37 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added show/hide password toggle buttons to both the "New Password" and "Confirm Password" input fields in the Reset Password form.
🎯 Why: Without visibility toggles, users are forced to guess if they made a typo when typing or confirming their new password, leading to frustration and potential lockouts.
📸 Before/After: Inputs previously lacked right-aligned interactive icons. They now have toggles that switch between eye and eye-slash icons, revealing or obscuring the input text.
♿ Accessibility: The toggle buttons include dynamic `aria-label`s that update based on state (e.g., "Show password" vs "Hide password"), making the interaction clear to screen reader users. The button type is explicitly set to `button` to prevent form submission.

---
*PR created automatically by Jules for task [10388343542838585011](https://jules.google.com/task/10388343542838585011) started by @parilsanghvi*