### PR TITLE
⚡ Bolt: Use estimatedDocumentCount for O(1) product counting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+## 2025-03-05 - Avoid O(N) Document Counting
+**Learning:** Using `countDocuments()` on a Mongoose model without providing any filter conditions forces MongoDB to perform a collection scan (or index scan if indexed) which operates in O(N) time. In contrast, `estimatedDocumentCount()` leverages collection metadata and returns an estimated count in O(1) time. This is especially problematic for large collections queried frequently, such as pagination endpoints for admin dashboards.
+**Action:** When counting the total number of documents in a collection where no query parameters are applied, always replace `Model.countDocuments()` with `Model.estimatedDocumentCount()`.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: Use estimatedDocumentCount() for O(1) counting instead of O(N) countDocuments() without filters
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `Product.countDocuments()` with `Product.estimatedDocumentCount()` inside the `getAdminProducts` controller.
🎯 Why: `countDocuments()` performs a full collection or index scan taking O(N) time when no filters are provided. For the admin products list, we simply need the total count, making `estimatedDocumentCount()` (which relies on collection metadata for O(1) time complexity) much more efficient.
📊 Impact: Reduces the time complexity of the counting step from O(N) to O(1), significantly improving the response time for large product catalogs.
🔬 Measurement: Verified the optimization by checking for syntax errors and running the unit testing suite to ensure backward compatibility and accurate response shapes.

---
*PR created automatically by Jules for task [2080858244222775694](https://jules.google.com/task/2080858244222775694) started by @parilsanghvi*