### PR TITLE
⚡ Bolt: [performance improvement] Optimize total count query in admin products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+## 2024-11-20 - O(N) Collection Scans in Count Queries
+**Learning:** Found that `Model.countDocuments()` is used in `backend/controllers/productController.js` for calculating total counts across the collection. In Mongoose, this performs an O(N) full collection or index scan when executed without a filter query.
+**Action:** Replace filter-less `countDocuments()` calls with `estimatedDocumentCount()`, which leverages MongoDB collection metadata for an immediate O(1) response, dramatically reducing load times and resource utilization on large datasets.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // Optimized: Use estimatedDocumentCount() for O(1) collection count retrieval
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `countDocuments()` with `estimatedDocumentCount()` in `getAdminProducts`.
🎯 Why: `countDocuments()` without filters performs a full collection or index scan (O(N)), causing unnecessary CPU and memory overhead on large product catalogs. `estimatedDocumentCount()` directly fetches the collection metadata size in O(1) time.
📊 Impact: Expected to reduce the admin dashboard total count query execution time to near 0ms, greatly lowering database load and improving response times.
🔬 Measurement: Verified that unit tests related to product counting still pass as expected and manually validated using `node -c` syntax tests. No visual changes; measure speed improvement via server-side benchmarks.

---
*PR created automatically by Jules for task [16207246988504064402](https://jules.google.com/task/16207246988504064402) started by @parilsanghvi*