### PR TITLE
🎨 Palette: Add password visibility toggle to reset password form

### DIFF
--- a/frontend/src/__tests__/components/ResetPassword.test.jsx
+++ b/frontend/src/__tests__/components/ResetPassword.test.jsx
@@ -49,4 +49,36 @@ describe('ResetPassword', () => {
         render(<ResetPassword />);
         expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument();
     });
+
+    it('toggles password visibility for new password', () => {
+        render(<ResetPassword />);
+
+        const newPasswordInput = screen.getByPlaceholderText('New Password');
+        expect(newPasswordInput).toHaveAttribute('type', 'password');
+
+        const toggleBtn = screen.getByLabelText('Show new password');
+        fireEvent.click(toggleBtn);
+
+        expect(newPasswordInput).toHaveAttribute('type', 'text');
+        expect(screen.getByLabelText('Hide new password')).toBeInTheDocument();
+
+        fireEvent.click(toggleBtn);
+        expect(newPasswordInput).toHaveAttribute('type', 'password');
+    });
+
+    it('toggles password visibility for confirm password', () => {
+        render(<ResetPassword />);
+
+        const confirmPasswordInput = screen.getByPlaceholderText('Confirm Password');
+        expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+        const toggleBtn = screen.getByLabelText('Show confirm password');
+        fireEvent.click(toggleBtn);
+
+        expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+        expect(screen.getByLabelText('Hide confirm password')).toBeInTheDocument();
+
+        fireEvent.click(toggleBtn);
+        expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    });
 });

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,10 +44,12 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -67,6 +69,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,37 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide new password" : "Show new password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 **What:** Added a password visibility toggle (show/hide password) to the ResetPassword component for both the "New Password" and "Confirm Password" inputs.
🎯 **Why:** To enhance user experience by allowing users to verify their input, thus preventing unseen typos and potential lockouts during the password reset process.
📸 **Before/After:** Added toggle functionality akin to what is currently established in `LoginSignup.jsx` and `UpdatePassword.jsx` forms.
♿ **Accessibility:** The toggle buttons include correct ARIA attributes (`aria-label`) that dynamically change based on the visible state of the inputs ("Show new password" vs "Hide new password").

All related tests passed successfully.

---
*PR created automatically by Jules for task [14407199361391260827](https://jules.google.com/task/14407199361391260827) started by @parilsanghvi*