### PR TITLE
🎨 Palette: Add password visibility toggles to Reset Password form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+## 2026-05-11 - Password Visibility Toggles on Reset Forms
+**Learning:** Adding password visibility toggles ('show/hide' buttons) is particularly critical on reset/update password forms, as users are locked out if they cannot verify they typed the new complex password correctly without typos.
+**Action:** Always verify all password input fields across the application (Login, Signup, Reset, Update) have a consistent visibility toggle to prevent friction and lockouts.

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,10 +44,12 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -67,6 +69,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -57,23 +61,41 @@ const ResetPassword = () => {
                 encType="multipart/form-data"
                 onSubmit={resetPasswordSubmit}
               >
-                <div >
+                <div className='loginPassword'>
                   <LockOpenIcon />
-                  <input type="password"
+                  <input
+                    type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
-                <div>
+                <div className='loginPassword'>
                   <LockIcon />
-                  <input type="password"
+                  <input
+                    type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added password visibility toggles ('show' and 'hide' buttons) to the "New Password" and "Confirm Password" input fields in the Reset Password form.
🎯 Why: Without visibility toggles, users are easily locked out of their accounts during the password reset process if they mistype their new complex password without knowing it. This small addition provides a significantly better user experience by allowing them to verify their keystrokes.
📸 Before/After: N/A
♿ Accessibility: Used semantic `<button>` tags with `type="button"` and added dynamic `aria-label` attributes (`Show password` / `Hide password`) to ensure screen reader users are aware of the toggle's function and state. Also added `pointer-events: none` to the decorative MUI icons.

---
*PR created automatically by Jules for task [4304701788684253103](https://jules.google.com/task/4304701788684253103) started by @parilsanghvi*