### PR TITLE
⚡ Bolt: [performance improvement] Optimize total product count using estimatedDocumentCount

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+## 2025-03-05 - Mongoose estimatedDocumentCount Optimization
+**Learning:** Using `countDocuments()` without filters executes an O(N) full collection scan in MongoDB. When counting all documents in a collection, Mongoose provides `estimatedDocumentCount()` which operates in O(1) time by reading collection metadata directly.
+**Action:** Always replace `Model.countDocuments()` with `Model.estimatedDocumentCount()` when no filter query is applied to significantly improve the performance of collection-wide counting operations.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: [performance improvement] Use estimatedDocumentCount() instead of countDocuments() for O(1) performance when no filters are applied
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -118,7 +118,7 @@ const Payment = () => {
 
       if (!stripe || !elements) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         return;
       }
 
@@ -141,7 +141,7 @@ const Payment = () => {
 
       if (result.error) {
         setIsProcessing(false);
-        payBtn.current.disabled = false;
+        if (payBtn.current) payBtn.current.disabled = false;
         setIsProcessing(false);
 
         enqueueSnackbar(result.error.message, { variant: "error" });
@@ -161,7 +161,7 @@ const Payment = () => {
           navigate("/success");
         } else {
           setIsProcessing(false);
-          payBtn.current.disabled = false;
+          if (payBtn.current) payBtn.current.disabled = false;
           enqueueSnackbar("There's some issue while processing payment ", {
             variant: "error",
           });
@@ -169,7 +169,7 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) payBtn.current.disabled = false;
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };


### PR DESCRIPTION
💡 What: Replaced `Model.countDocuments()` with `Model.estimatedDocumentCount()` in the `getAdminProducts` controller.
🎯 Why: `countDocuments()` executes an O(N) full collection scan when no filters are provided. `estimatedDocumentCount()` reads collection metadata directly, resulting in O(1) time complexity.
📊 Impact: Significantly improves the response time of the `getAdminProducts` endpoint, especially for databases with a large number of products, avoiding slow full collection scans.
🔬 Measurement: Verify by measuring the execution time of `getAdminProducts` or running the backend test suite `pnpm test:backend backend/tests/productController_getAdminProducts.test.js`.

---
*PR created automatically by Jules for task [13901875659511996986](https://jules.google.com/task/13901875659511996986) started by @parilsanghvi*