### PR TITLE
🎨 Palette: Add password visibility toggle to Reset Password form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+
+## $(date +%Y-%m-%d) - Password Visibility Toggle
+**Learning:** Decorative SVG icons placed over absolute-positioned toggles must use `pointer-events: none` to prevent them from intercepting clicks meant for the toggle button.
+**Action:** When adding layered interactive elements, ensure all decorative siblings have `pointer-events: none` applied.

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -44,10 +44,12 @@
   width: 100%;
   align-items: center;
   margin-bottom: 1rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
@@ -67,6 +69,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,37 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added show/hide password visibility toggles to the "New Password" and "Confirm Password" input fields on the Reset Password page.
🎯 Why: Prevents user frustration by allowing them to visually confirm their newly typed passwords before submission, mitigating the risk of typos that could lock them out. This also brings the Reset Password page into alignment with the existing UX patterns found on the Login/Signup and Update Password pages.
📸 Before/After: (Screenshot recorded in verification process) The input fields now feature an eye icon on the right side.
♿ Accessibility: Implemented using `<button type="button">` with dynamic `aria-label` attributes (`"Show password"`/`"Hide password"`) that communicate state clearly to screen readers. Also ensured decorative SVG lock icons use `pointer-events: none` to avoid intercepting clicks.

---
*PR created automatically by Jules for task [17424446028218927512](https://jules.google.com/task/17424446028218927512) started by @parilsanghvi*