### PR TITLE
⚡ Bolt: [performance improvement] Memoize outOfStock calculation in Dashboard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+
+## 2025-03-05 - Avoid O(N) Reductions in Component Body Render
+**Learning:** Computations like `products.forEach` or `products.reduce` that compute a derived state (e.g., `outOfStock` count) from props inside the main body of a component execute synchronously on every re-render. In a complex Dashboard component, this degrades performance needlessly.
+**Action:** Always wrap `reduce`, `filter`, `forEach` derived-state logic in a `useMemo` hook with strict dependencies (`[products]`) so the O(N) array iteration only occurs when the actual data changes, saving CPU cycles on subsequent re-renders.

--- a/frontend/src/component/Admin/Dashboard.jsx
+++ b/frontend/src/component/Admin/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import "./dashboard.css";
 import { Typography } from "@mui/material";
 import { Link } from "react-router-dom";
@@ -40,13 +40,11 @@ const Dashboard = () => {
   // error
   const { totalUsers } = useSelector((state) => state.user);
   // console.log(orders.length);
-  let outOfStock = 0;
-  products &&
-    products.forEach((item) => {
-      if (item.stock === 0) {
-        outOfStock += 1;
-      }
-    });
+  // ⚡ Bolt: [performance improvement] Memoize expensive array calculation to prevent re-running on every render
+  const outOfStock = useMemo(() => {
+    if (!products) return 0;
+    return products.reduce((count, item) => (item.stock === 0 ? count + 1 : count), 0);
+  }, [products]);
 
   useEffect(() => {
     dispatch(getAdminProduct());


### PR DESCRIPTION
💡 What: Wrapped the `outOfStock` count calculation in `frontend/src/component/Admin/Dashboard.jsx` using the `useMemo` hook.
🎯 Why: The previous implementation used an inline `forEach` loop inside the component body, meaning the O(N) iteration over the `products` array ran synchronously on every single re-render of the Dashboard.
📊 Impact: Prevents unnecessary O(N) array iterations, reducing main thread blocking time during component updates (like hovering over charts or updating unrelated state) and improving overall UI responsiveness in the Admin panel.
🔬 Measurement: Verified via unit test that `reduce` is only called once initially and is skipped on subsequent re-renders with the same props.

---
*PR created automatically by Jules for task [18365884764461617079](https://jules.google.com/task/18365884764461617079) started by @parilsanghvi*