### PR TITLE
🎨 Palette: [UX improvement] Add accessible error states to LoginSignup

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-03-06 - Add ARIA label to 'X' icon buttons
 **Learning:** Text closures like 'X' are ambiguous for screen readers and must be equipped with descriptive `aria-label` attributes to support proper screen reader functionality.
 **Action:** Always add an `aria-label` to visually-driven interactive elements or ambiguous text closures.
+
+## 2026-05-17 - Accessible Error States
+**Learning:** Dynamic error messages in forms need 'role="alert"' and 'aria-live="assertive"' for immediate screen reader announcement.
+**Action:** Always add these attributes and hide decorative icons ('aria-hidden="true"') in custom error toasts/messages.

--- a/frontend/src/component/User/LoginSignup.jsx
+++ b/frontend/src/component/User/LoginSignup.jsx
@@ -148,9 +148,9 @@ const LoginSignup = () => {
                         <div className="slider-line" ref={switcherTab}></div>
                     </div >
                     {(error || localError) && (
-                        <div className="loginError">
-                            <MdErrorOutline />
-                            <span>{localError || (error === "Field value too long" ? "File is too large" : error)}</span>
+                        <div className="loginError" role="alert" aria-live="assertive">
+                            <MdErrorOutline aria-hidden="true" />
+                            <span>{localError || (error === "Field value too long" ? "File is too large (max 750KB)" : error)}</span>
                         </div>
                     )}
                     <form


### PR DESCRIPTION
💡 **What:** Added accessibility attributes (`role="alert"` and `aria-live="assertive"`) to the error message block in `LoginSignup.jsx` and hid the decorative `MdErrorOutline` icon from assistive tech. Also clarified the "File is too large" error string to explicitly state the limit (max 750KB).

🎯 **Why:** To ensure screen readers immediately announce form errors (like invalid credentials or oversized file uploads) so visually impaired users aren't left confused, and to give all users clearer, actionable feedback when an avatar upload fails.

📸 **Before/After:**
*(Before)* Error message div lacked semantic roles, meaning screen readers might not announce it immediately. File upload error just said "File is too large".
*(After)* Error message div now has `role="alert"` and `aria-live="assertive"`. Icon is hidden with `aria-hidden="true"`. File upload error says "File is too large (max 750KB)".

♿ **Accessibility:**
- Added `role="alert"`
- Added `aria-live="assertive"`
- Added `aria-hidden="true"` to decorative `<MdErrorOutline />`
- Clarified error text limit

---
*PR created automatically by Jules for task [2011774310591541628](https://jules.google.com/task/2011774310591541628) started by @parilsanghvi*