### PR TITLE
⚡ Bolt: [performance improvement] Optimize total product count in getAdminProducts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,7 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+
+## 2025-03-08 - Use estimatedDocumentCount when no filters applied
+**Learning:** Using `countDocuments()` performs an O(N) full collection scan even when there are no query filters. This is inefficient for retrieving the total count of documents in a collection.
+**Action:** When retrieving the total document count of a collection without applying any query filters (e.g., getting the total number of products), use `Model.estimatedDocumentCount()` instead. This leverages an O(1) metadata lookup, significantly improving performance.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,10 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: [performance improvement] Use estimatedDocumentCount() instead of countDocuments()
+    // Since there are no query filters here, estimatedDocumentCount() is an O(1) operation
+    // that uses collection metadata rather than doing an O(N) full collection scan.
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `Product.countDocuments()` with `Product.estimatedDocumentCount()` in `getAdminProducts`.
🎯 Why: `countDocuments()` performs an O(N) full collection scan even when there are no query filters. `estimatedDocumentCount()` leverages collection metadata for an O(1) operation.
📊 Impact: Significantly improves the performance of the `/admin/products` endpoint by reducing database load and query execution time for counting total products.
🔬 Measurement: Verify by executing the `product_count_optimization.test.js` tests to ensure the behavior is preserved and optimizations are used appropriately. Also, this resolves the potential bottlenecks in backend scaling.

---
*PR created automatically by Jules for task [9520784926798178782](https://jules.google.com/task/9520784926798178782) started by @parilsanghvi*