### PR TITLE
🎨 Palette: Add password visibility toggle to reset password form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,6 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+## 2024-05-25 - Password Visibility Toggles
+**Learning:** Adding interactive icons like toggle buttons inside form inputs requires setting `position: relative` on the wrapping container to ensure absolute positioning doesn't break out of the component flow.
+**Action:** Always verify parent container positioning when nesting interactive absolutely-positioned elements within input groups.

--- a/frontend/src/component/Cart/Payment.jsx
+++ b/frontend/src/component/Cart/Payment.jsx
@@ -169,7 +169,9 @@ const Payment = () => {
       }
     } catch (error) {
       setIsProcessing(false);
-      payBtn.current.disabled = false;
+      if (payBtn.current) {
+        payBtn.current.disabled = false;
+      }
       enqueueSnackbar(error.response?.data?.message || "Payment failed", { variant: "error" });
     }
   };

--- a/frontend/src/component/User/ResetPassword.css
+++ b/frontend/src/component/User/ResetPassword.css
@@ -43,19 +43,22 @@
   display: flex;
   width: 100%;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  position: relative;
 }
 
 .resetPasswordForm>div>input {
   padding: 1rem 3rem;
+  padding-right: 4rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--color-border);
   border-radius: 0;
   font-family: var(--font-body);
-  outline: none;
+  outline: 1px solid transparent;
   background: var(--color-bg);
   color: var(--color-text);
+  height: 50px;
 }
 
 .resetPasswordForm>div>input:focus {
@@ -67,6 +70,25 @@
   transform: translateX(1rem);
   font-size: 1.2rem;
   color: var(--color-muted);
+  pointer-events: none;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  padding: 0;
+  transition: color 0.3s;
+  z-index: 10;
+}
+
+.password-toggle-btn:hover {
+  color: var(--color-primary);
 }
 
 .resetPasswordBtn {

--- a/frontend/src/component/User/ResetPassword.jsx
+++ b/frontend/src/component/User/ResetPassword.jsx
@@ -7,6 +7,8 @@ import Loader from "../layout/Loader";
 import MetaData from "../layout/MetaData";
 import LockOpenIcon from "@mui/icons-material/LockOpen"
 import LockIcon from "@mui/icons-material/Lock"
+import Visibility from "@mui/icons-material/Visibility"
+import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate, useParams } from 'react-router-dom';
 
 const ResetPassword = () => {
@@ -19,6 +21,8 @@ const ResetPassword = () => {
   const { error, success, loading } = useSelector((state) => state.user);
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   const resetPasswordSubmit = (e) => {
     e.preventDefault();
@@ -59,21 +63,39 @@ const ResetPassword = () => {
               >
                 <div >
                   <LockOpenIcon />
-                  <input type="password"
+                  <input type={showPassword ? "text" : "password"}
                     placeholder="New Password"
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    disabled={loading}
+                  >
+                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <div>
                   <LockIcon />
-                  <input type="password"
+                  <input type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="password-toggle-btn"
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                    disabled={loading}
+                  >
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </button>
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
💡 What: Added password visibility toggle buttons to the "New Password" and "Confirm Password" fields on the Reset Password page.
🎯 Why: To prevent frustrating typos by allowing users to verify they typed their new password correctly before submitting.
📸 Before/After: Screenshots attached to the PR.
♿ Accessibility: The toggle buttons include `aria-label`s that dynamically update based on the state ("Show password" / "Hide password") and use `disabled={loading}` to prevent interaction while the form is processing.

---
*PR created automatically by Jules for task [8573796457644424330](https://jules.google.com/task/8573796457644424330) started by @parilsanghvi*