### PR TITLE
⚡ Bolt: Optimize total count query in getAdminProducts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -46,3 +46,6 @@
 ## 2025-03-04 - Safely parsing JSON from sessionStorage
 **Learning:** During tests or specific execution paths, `sessionStorage.getItem()` may return `undefined` (as a string) or fail to parse if the stored JSON string is corrupt or simply empty. Simply passing the result directly to `JSON.parse` (e.g., `JSON.parse(sessionStorage.getItem('key'))`) will throw a `SyntaxError` if it evaluates to `undefined`, breaking components like `Payment`.
 **Action:** Always wrap `JSON.parse` operations that source data from `sessionStorage` or `localStorage` inside a `try...catch` block, and provide a secure fallback initialization state to ensure component resilience.
+## 2025-05-27 - Fast Document Counting in Mongoose
+**Learning:** Using `countDocuments()` on a Mongoose model performs an O(N) index scan, which becomes very slow for large collections. If no query filters are applied (e.g., getting the total count of all products), using `estimatedDocumentCount()` is significantly faster as it operates in O(1) time by reading MongoDB collection metadata.
+**Action:** Always prefer `estimatedDocumentCount()` over `countDocuments()` when calculating the total size of an unfiltered collection to prevent unnecessary database load and improve response times.

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -100,7 +100,8 @@ exports.getAdminProducts = catchAsyncErrors(async (req, res, next) => {
     const limit = Number(queryParams.limit) || 0; // 0 means no limit (legacy behavior if not provided)
     const skip = (page - 1) * limit;
 
-    const totalCount = await Product.countDocuments();
+    // ⚡ Bolt: Use estimatedDocumentCount() for O(1) performance instead of O(N) full collection scan
+    const totalCount = await Product.estimatedDocumentCount();
 
     let query = Product.find().select("name price stock").lean();
 


### PR DESCRIPTION
💡 What: Replaced `countDocuments()` with `estimatedDocumentCount()` in `getAdminProducts`.
🎯 Why: `countDocuments()` forces MongoDB to scan the entire index (O(N) operation). Since the admin product list queries the total unfiltered count, using `estimatedDocumentCount()` leverages collection metadata (O(1) operation), preventing performance bottlenecks as the product catalog scales.
📊 Impact: Significant reduction in query execution time for the admin product list endpoint, saving memory and CPU cycles on the database server.
🔬 Measurement: Backend benchmark tests verified the execution time improvement, and integration tests confirmed accurate pagination counts.

---
*PR created automatically by Jules for task [7449661441249334917](https://jules.google.com/task/7449661441249334917) started by @parilsanghvi*