### PR TITLE
🧪 Add tests for createThunkHandler

### DIFF
--- a/frontend/src/utils/__tests__/thunkHandler.test.js
+++ b/frontend/src/utils/__tests__/thunkHandler.test.js
@@ -1,0 +1,78 @@
+import { vi, describe, it, expect } from 'vitest';
+import { createThunkHandler } from '../thunkHandler';
+
+describe('createThunkHandler', () => {
+    it('should return the result of the handler on success', async () => {
+        const mockHandler = vi.fn().mockResolvedValue('success data');
+        const thunk = createThunkHandler(mockHandler);
+
+        const arg = { id: 1 };
+        const thunkAPI = {};
+
+        const result = await thunk(arg, thunkAPI);
+
+        expect(mockHandler).toHaveBeenCalledWith(arg, thunkAPI);
+        expect(result).toBe('success data');
+    });
+
+    it('should call rejectWithValue with response.data.message if available', async () => {
+        const error = new Error('Network Error');
+        error.response = {
+            data: {
+                message: 'Custom API error message'
+            }
+        };
+        const mockHandler = vi.fn().mockRejectedValue(error);
+        const thunk = createThunkHandler(mockHandler);
+
+        const arg = { id: 1 };
+        const thunkAPI = {
+            rejectWithValue: vi.fn().mockImplementation((val) => `rejected: ${val}`)
+        };
+
+        const result = await thunk(arg, thunkAPI);
+
+        expect(mockHandler).toHaveBeenCalledWith(arg, thunkAPI);
+        expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('Custom API error message');
+        expect(result).toBe('rejected: Custom API error message');
+    });
+
+    it('should call rejectWithValue with error.message if response.data.message is not available', async () => {
+        const error = new Error('Standard Error');
+        const mockHandler = vi.fn().mockRejectedValue(error);
+        const thunk = createThunkHandler(mockHandler);
+
+        const arg = { id: 1 };
+        const thunkAPI = {
+            rejectWithValue: vi.fn().mockImplementation((val) => `rejected: ${val}`)
+        };
+
+        const result = await thunk(arg, thunkAPI);
+
+        expect(mockHandler).toHaveBeenCalledWith(arg, thunkAPI);
+        expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('Standard Error');
+        expect(result).toBe('rejected: Standard Error');
+    });
+
+    it('should call rejectWithValue with error.message if response exists but data.message does not', async () => {
+        const error = new Error('Fallback Error');
+        error.response = {
+            data: {
+                otherField: 'something'
+            }
+        };
+        const mockHandler = vi.fn().mockRejectedValue(error);
+        const thunk = createThunkHandler(mockHandler);
+
+        const arg = { id: 1 };
+        const thunkAPI = {
+            rejectWithValue: vi.fn().mockImplementation((val) => `rejected: ${val}`)
+        };
+
+        const result = await thunk(arg, thunkAPI);
+
+        expect(mockHandler).toHaveBeenCalledWith(arg, thunkAPI);
+        expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('Fallback Error');
+        expect(result).toBe('rejected: Fallback Error');
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `createThunkHandler` utility function in `frontend/src/utils/thunkHandler.js` to close the testing gap for standard error handling logic in Redux Toolkit thunks.
📊 **Coverage:** Covered all scenarios for this higher-order function: successful handler execution, extraction of nested API error messages (`error.response.data.message`), handling of standard errors (`error.message`), and edge cases where a response object exists but lacks a `.data.message` field.
✨ **Result:** Improved test coverage and reliability for thunk error handling. Prevents regressions if standard error shapes change.

---
*PR created automatically by Jules for task [5640876637057091902](https://jules.google.com/task/5640876637057091902) started by @parilsanghvi*