### PR TITLE
🧪 [testing improvement] Add test for missing FRONTEND_URL in forgotPassword

### DIFF
--- a/backend/tests/security_forgot_password.test.js
+++ b/backend/tests/security_forgot_password.test.js
@@ -52,14 +52,38 @@ afterEach(async () => {
 });
 
 describe('Security: Forgot Password Enumeration', () => {
-    const originalEnv = process.env.FRONTEND_URL;
+    let originalEnv;
 
     beforeEach(() => {
+        originalEnv = process.env.FRONTEND_URL;
         process.env.FRONTEND_URL = 'http://localhost:3000';
     });
 
     afterEach(() => {
-        process.env.FRONTEND_URL = originalEnv;
+        if (originalEnv === undefined) {
+            delete process.env.FRONTEND_URL;
+        } else {
+            process.env.FRONTEND_URL = originalEnv;
+        }
+    });
+
+    it('should return error when FRONTEND_URL is not configured', async () => {
+        delete process.env.FRONTEND_URL;
+
+        await User.create({
+            name: 'Test User',
+            email: 'test@example.com',
+            password: 'password123',
+            avatar: { public_id: 'id', url: 'url' }
+        });
+
+        const res = await request(app)
+            .post('/api/v1/password/forgot')
+            .send({ email: 'test@example.com' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+        expect(res.body.message).toBe('FRONTEND_URL is not configured on the server.');
     });
 
     it('should return generic success message for non-existent email', async () => {


### PR DESCRIPTION
🎯 **What:** The `forgotPassword` controller contains security logic that throws a 500 error when `process.env.FRONTEND_URL` is not set, preventing Host Header Injection. This behavior was not previously tested.
📊 **Coverage:** A new test case `should return error when FRONTEND_URL is not configured` was added to `backend/tests/security_forgot_password.test.js`. It simulates a missing `FRONTEND_URL` by using `delete process.env.FRONTEND_URL` and asserts that the API correctly returns a `500` error with the message "FRONTEND_URL is not configured on the server.".
✨ **Result:** Increased test coverage and confidence by verifying the security error-handling pathway. Also fixed an issue in the environment setup hooks where setting an undefined environment variable actually coerced it to the string `"undefined"` instead of explicitly deleting it.

---
*PR created automatically by Jules for task [16931163817824874233](https://jules.google.com/task/16931163817824874233) started by @parilsanghvi*