### PR TITLE
🧪 Add test for localStorage initialization in cartSlice

### DIFF
--- a/frontend/src/__tests__/slices/cartSlice.test.js
+++ b/frontend/src/__tests__/slices/cartSlice.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import cartReducer, {
     removeItemsFromCart,
     saveShippingInfo,
@@ -17,6 +17,22 @@ describe('cartSlice', () => {
 
     beforeEach(() => {
         localStorage.clear();
+    });
+
+    describe('initial state from localStorage', () => {
+        it('should load cartItems and shippingInfo from localStorage', async () => {
+            vi.resetModules();
+            localStorage.setItem('cartItems', JSON.stringify([{ product: 'p1', name: 'Item', price: 100 }]));
+            localStorage.setItem('shippingInfo', JSON.stringify({ address: '456 Ave' }));
+
+            const { default: reducer } = await import('../../features/cartSlice');
+
+            const state = reducer(undefined, { type: 'unknown' });
+
+            expect(state.cartItems).toHaveLength(1);
+            expect(state.cartItems[0].product).toBe('p1');
+            expect(state.shippingInfo.address).toBe('456 Ave');
+        });
     });
 
     describe('removeItemsFromCart', () => {


### PR DESCRIPTION
🎯 **What:** Adding test coverage for cartSlice initial state loading from localStorage.
📊 **Coverage:** Scenario where cartItems and shippingInfo are present in localStorage before the slice is initialized.
✨ **Result:** Improved test coverage and reliability for state initialization.

---
*PR created automatically by Jules for task [555197254682219935](https://jules.google.com/task/555197254682219935) started by @parilsanghvi*