### PR TITLE
🧪 [Test error handling in userSlice createThunkHandler]

### DIFF
--- a/frontend/src/__tests__/slices/userSlice.test.js
+++ b/frontend/src/__tests__/slices/userSlice.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer, {
+    createThunkHandler,
     clearErrors,
     updateProfileReset,
     updatePasswordReset,
@@ -40,6 +41,56 @@ vi.mock('axios');
 describe('userSlice', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('createThunkHandler', () => {
+        it('should return the result of the async function on success', async () => {
+            const mockAsyncFunction = vi.fn().mockResolvedValue('success data');
+            const thunkAPI = { rejectWithValue: vi.fn() };
+            const arg = { id: 1 };
+
+            const handler = createThunkHandler(mockAsyncFunction);
+            const result = await handler(arg, thunkAPI);
+
+            expect(mockAsyncFunction).toHaveBeenCalledWith(arg, thunkAPI);
+            expect(result).toBe('success data');
+            expect(thunkAPI.rejectWithValue).not.toHaveBeenCalled();
+        });
+
+        it('should return rejectWithValue with response.data.message on API error', async () => {
+            const mockAsyncFunction = vi.fn().mockRejectedValue({
+                response: { data: { message: 'API error message' } }
+            });
+            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
+
+            const handler = createThunkHandler(mockAsyncFunction);
+            const result = await handler(null, thunkAPI);
+
+            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('API error message');
+            expect(result).toBe('rejected: API error message');
+        });
+
+        it('should return rejectWithValue with error.message on standard error', async () => {
+            const mockAsyncFunction = vi.fn().mockRejectedValue(new Error('Network error'));
+            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
+
+            const handler = createThunkHandler(mockAsyncFunction);
+            const result = await handler(null, thunkAPI);
+
+            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('Network error');
+            expect(result).toBe('rejected: Network error');
+        });
+
+        it('should return rejectWithValue with default message when error has no standard message fields', async () => {
+            const mockAsyncFunction = vi.fn().mockRejectedValue({});
+            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
+
+            const handler = createThunkHandler(mockAsyncFunction);
+            const result = await handler(null, thunkAPI);
+
+            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('An error occurred');
+            expect(result).toBe('rejected: An error occurred');
+        });
     });
 
     describe('synchronous reducers', () => {


### PR DESCRIPTION
🎯 **What:** The `createThunkHandler` utility exported inside `frontend/src/features/userSlice.js` lacked direct test coverage, leading to a testing gap for thunk error handling within the slice.
    
📊 **Coverage:** Added tests inside `frontend/src/__tests__/slices/userSlice.test.js` to specifically test the behavior of `createThunkHandler`. The test cases verify that it correctly handles successful async function results, extracts `error.response.data.message` on API errors, falls back to `error.message` on standard errors, and finally uses "An error occurred" as a default fallback message.

✨ **Result:** Increased test coverage for thunk error handling ensuring the correct error strings are populated, providing better confidence when refactoring async thunks in the slice.

---
*PR created automatically by Jules for task [2142086490159145227](https://jules.google.com/task/2142086490159145227) started by @parilsanghvi*