### PR TITLE
🎨 Palette: Add accessibility labels and loading states to Update Profile form

### DIFF
--- a/frontend/src/component/Admin/UpdateProduct.jsx
+++ b/frontend/src/component/Admin/UpdateProduct.jsx
@@ -233,7 +233,6 @@ const UpdateProduct = () => {
                   type="button"
                   aria-label="Remove image"
                   onClick={() => removeImage(index)}
-                  aria-label="Remove image"
                   style={{
                     position: 'absolute',
                     top: '-10px',

--- a/frontend/src/component/User/UpdateProfile.jsx
+++ b/frontend/src/component/User/UpdateProfile.jsx
@@ -81,25 +81,29 @@ const UpdateProfile = () => {
                 onSubmit={updateProfileSubmit}
               >
                 <div className="updateProfileName">
-                  <FaceIcon />
+                  <FaceIcon aria-hidden="true" />
                   <input
                     type="text"
                     placeholder="Name"
+                    aria-label="Name"
                     required
                     name="name"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
+                    disabled={loading}
                   />
                 </div>
                 <div className="updateProfileEmail">
-                  <MailOutlineIcon />
+                  <MailOutlineIcon aria-hidden="true" />
                   <input
                     type="email"
                     placeholder="Email"
+                    aria-label="Email"
                     required
                     name="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
+                    disabled={loading}
                   />
                 </div>
 
@@ -109,7 +113,9 @@ const UpdateProfile = () => {
                     type="file"
                     name="avatar"
                     accept="image/*"
+                    aria-label="Avatar Upload"
                     onChange={updateProfileDataChange}
+                    disabled={loading}
                   />
                 </div>
                 <button


### PR DESCRIPTION
💡 What: Added `aria-label`s to the Update Profile form fields ("Name", "Email", and "Avatar"). Hidden the decorative `FaceIcon` and `MailOutlineIcon` from screen readers using `aria-hidden="true"`. Finally, added `disabled={loading}` to all form inputs to prevent interaction while the asynchronous update is processing.
🎯 Why: The form inputs previously lacked accessible names because they only used visual placeholders and icons, making them inaccessible to screen reader users. The decorative icons also cluttered the screen reader output. Furthermore, only the submit button was disabled during form submission, leaving the input fields vulnerable to accidental modification.
📸 Before/After: N/A (Visual changes are non-existent, these are under-the-hood a11y improvements).
♿ Accessibility: Ensures that users navigating via screen readers can understand the purpose of each form field without redundant icon noise, and locks form interaction during asynchronous API operations to ensure state consistency.

---
*PR created automatically by Jules for task [13550297096452808988](https://jules.google.com/task/13550297096452808988) started by @parilsanghvi*