### PR TITLE
⚡ Bolt: parallelize Cloudinary and DB deletions

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -165,8 +165,13 @@ exports.deleteProduct = catchAsyncErrors(async (req, res, next) => {
     if (!product) {
         return next(new ErrorHandler("product not found", 404))
     }
-    await Promise.all(product.images.map(image => cloudinary.v2.uploader.destroy(image.public_id)));
-    await product.deleteOne();
+    // ⚡ Bolt: [performance improvement] Parallelize Cloudinary destroy and database delete
+    // Previously these were sequential, taking T(destroy) + T(delete) time.
+    // Now they run concurrently, taking MAX(T(destroy), T(delete)) time.
+    await Promise.all([
+        ...product.images.map(image => cloudinary.v2.uploader.destroy(image.public_id)),
+        product.deleteOne()
+    ]);
     res.status(200).json({
         success: true,
         message: "product deleted"

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -265,8 +265,13 @@ exports.deleteUser = catchAsyncErrors(async (req, res, next) => {
         return next(new ErrorHandler(`user doesnot exist with id of ${req.params.id}`, 404))
     }
     const imageId = user.avatar.public_id
-    await cloudinary.v2.uploader.destroy(imageId);
-    await user.deleteOne();
+    // ⚡ Bolt: [performance improvement] Parallelize Cloudinary destroy and database delete
+    // Previously these were sequential, taking T(destroy) + T(delete) time.
+    // Now they run concurrently, taking MAX(T(destroy), T(delete)) time.
+    await Promise.all([
+        cloudinary.v2.uploader.destroy(imageId),
+        user.deleteOne()
+    ]);
     res.status(200).json({
         success: true,
         message: "user deleted successfully"


### PR DESCRIPTION
💡 **What**: Changed sequential `cloudinary.destroy` and `model.deleteOne` operations to run concurrently using `Promise.all` in the `deleteUser` and `deleteProduct` controllers.

🎯 **Why**: When an admin deletes a user or a product, the application must delete the document from MongoDB and the associated image(s) from Cloudinary. Previously, the application waited for Cloudinary to finish before initiating the database deletion ($T_{cloudinary} + T_{database}$). These are independent I/O boundaries. 

📊 **Impact**: Total latency for these endpoints is reduced from $T_{cloudinary} + T_{database}$ to $\max(T_{cloudinary}, T_{database})$. Local benchmarks show execution time dropping from ~100ms to ~50ms. 

🔬 **Measurement**: Benchmarks were added locally during exploration (mocking 50ms I/O latency) which verified the speedup. No existing unit or integration tests were broken.

---
*PR created automatically by Jules for task [4290961966417454358](https://jules.google.com/task/4290961966417454358) started by @parilsanghvi*