### PR TITLE
🎨 Palette: Improve UpdatePassword UX and Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+
+## 2025-05-31 - Heading Copy-Paste Errors and Input State Management
+**Learning:** Found an incorrect "Update Profile" heading inside an "UpdatePassword" component, likely due to copy-pasting code during initial development. Additionally, inputs lacked `aria-label` and `disabled={loading}` props to prevent modifications mid-submission.
+**Action:** When reviewing forms, always verify that headings match the component's actual purpose and ensure all inputs have proper label associations and loading state management.

--- a/frontend/src/__tests__/components/UpdatePassword.test.jsx
+++ b/frontend/src/__tests__/components/UpdatePassword.test.jsx
@@ -62,6 +62,6 @@ describe('UpdatePassword', () => {
 
     it('renders heading', () => {
         render(<UpdatePassword />);
-        expect(screen.getByText('Update Profile')).toBeInTheDocument();
+        expect(screen.getByText('Update Password')).toBeInTheDocument();
     });
 });

--- a/frontend/src/component/User/UpdatePassword.jsx
+++ b/frontend/src/component/User/UpdatePassword.jsx
@@ -57,7 +57,7 @@ const UpdatePassword = () => {
           <MetaData title="Change Password" />
           <div className="updatePasswordContainer">
             <div className="updatePasswordBox">
-              <h2 className="updatePasswordHeading">Update Profile</h2>
+              <h2 className="updatePasswordHeading">Update Password</h2>
 
               <form
                 className="updatePasswordForm"
@@ -69,15 +69,18 @@ const UpdatePassword = () => {
                   <input
                     type={showOldPassword ? "text" : "password"}
                     placeholder="Old Password"
+                    aria-label="Old Password"
                     required
                     value={oldPassword}
                     onChange={(e) => setOldPassword(e.target.value)}
+                    disabled={loading}
                   />
                   <button
                     type="button"
                     onClick={() => setShowOldPassword(!showOldPassword)}
                     className="password-toggle-btn"
                     aria-label={showOldPassword ? "Hide old password" : "Show old password"}
+                    disabled={loading}
                   >
                     {showOldPassword ? <VisibilityOff /> : <Visibility />}
                   </button>
@@ -87,15 +90,18 @@ const UpdatePassword = () => {
                   <input
                     type={showNewPassword ? "text" : "password"}
                     placeholder="New Password"
+                    aria-label="New Password"
                     required
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
+                    disabled={loading}
                   />
                   <button
                     type="button"
                     onClick={() => setShowNewPassword(!showNewPassword)}
                     className="password-toggle-btn"
                     aria-label={showNewPassword ? "Hide new password" : "Show new password"}
+                    disabled={loading}
                   >
                     {showNewPassword ? <VisibilityOff /> : <Visibility />}
                   </button>
@@ -105,15 +111,18 @@ const UpdatePassword = () => {
                   <input
                     type={showConfirmPassword ? "text" : "password"}
                     placeholder="Confirm Password"
+                    aria-label="Confirm Password"
                     required
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
+                    disabled={loading}
                   />
                   <button
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="password-toggle-btn"
                     aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                    disabled={loading}
                   >
                     {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
                   </button>


### PR DESCRIPTION
💡 **What:** Fixed an incorrect form heading ("Update Profile" -> "Update Password"), added `aria-label` attributes to the password inputs, and disabled the inputs/toggle buttons when the form is loading.
🎯 **Why:** Prevents user confusion by clearly indicating the form's purpose, ensures screen reader compatibility for fields relying only on placeholders, and prevents mid-submission modifications.
♿ **Accessibility:** Added `aria-label` to three password input fields. Disabled inputs/buttons correctly tie into the `loading` state.
📸 **Before/After:** The heading now accurately reflects the action, and loading states apply universally to the form fields.

---
*PR created automatically by Jules for task [2235250093323197947](https://jules.google.com/task/2235250093323197947) started by @parilsanghvi*