### PR TITLE
🎨 Palette: Refactor Search submit input to button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,6 @@
 ## 2025-05-27 - Forms Without Buttons
 **Learning:** Legacy form submissions using `<input type="submit">` cannot display complex internal content like inline loading spinners natively without hacky CSS/background-image workarounds, leading to missing loading states during long-running async tasks.
 **Action:** When working on form UX, proactively refactor `<input type="submit">` elements to `<button type="submit">` and combine with an internal loading state to render spinners or contextual feedback. Update any associated unit tests that were targeting inputs via `getByDisplayValue` to look for button roles.
+## 2025-05-27 - Semantic Search Buttons
+**Learning:** Found `<input type="submit">` being used for search forms. While functional, it limits styling options (like adding an inner icon) and is less semantically clear than `<button type="submit">`.
+**Action:** When working on search interfaces or forms, proactively convert `<input type="submit">` to `<button type="submit">` to allow for richer internal content (like icons or loading spinners) and better semantic meaning. Ensure associated tests querying by `getByDisplayValue` are updated to `getByRole('button')`.

--- a/frontend/src/__tests__/components/Search.test.jsx
+++ b/frontend/src/__tests__/components/Search.test.jsx
@@ -23,7 +23,7 @@ describe('Search', () => {
     it('renders search input and button', () => {
         render(<Search />);
         expect(screen.getByPlaceholderText('Search products...')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('Search')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
     });
 
     it('has accessible aria-label', () => {

--- a/frontend/src/component/Product/Search.jsx
+++ b/frontend/src/component/Product/Search.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState } from 'react'
 import "./Search.css"
 import MetaData from "../layout/MetaData"
 import { useNavigate } from 'react-router-dom'
+import SearchIcon from '@mui/icons-material/Search'
 
 const Search = () => {
     const [keyword, setKeyword] = useState("")
@@ -26,7 +27,10 @@ const Search = () => {
                     autoFocus
                     onChange={(e) => setKeyword(e.target.value)}
                 />
-                <input type="submit" value="Search" className="primary-btn" style={{ width: 'auto', padding: '0 2rem', height: '60px' }} />
+                <button type="submit" className="primary-btn" style={{ width: 'auto', padding: '0 2rem', height: '60px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+                    <SearchIcon />
+                    Search
+                </button>
             </form>
         </Fragment>
     )


### PR DESCRIPTION
💡 What: Replaced legacy `<input type="submit">` with a semantic `<button type="submit">` containing a Material UI `SearchIcon` and updated the corresponding test to query by role instead of display value.
🎯 Why: `<button>` tags allow for richer internal content (like icons) compared to `<input>` tags, providing better visual feedback and semantic structure.
📸 Before/After: Replaced standard text input button with a button containing an inline magnifying glass icon, matching the layout styling.
♿ Accessibility: Uses proper button role and improves the visual affordance of the search action.

---
*PR created automatically by Jules for task [17394707505383505645](https://jules.google.com/task/17394707505383505645) started by @parilsanghvi*