### PR TITLE
🧪 [testing improvement] Add getSingleOrder test

### DIFF
--- a/backend/tests/unit/orderController_getSingleOrder.test.js
+++ b/backend/tests/unit/orderController_getSingleOrder.test.js
@@ -1,0 +1,84 @@
+const Order = require("../../models/orderModel");
+const User = require("../../models/userModel");
+const ErrorHandler = require("../../utils/errorhandler");
+
+// Mock catchAsyncErrors before requiring the controller
+jest.mock("../../middleware/catchAsyncErrors", () => (func) => (req, res, next) => {
+  return Promise.resolve(func(req, res, next)).catch(next);
+});
+
+// Mock Order and User models
+jest.mock("../../models/orderModel");
+jest.mock("../../models/userModel", () => ({}), { virtual: true });
+jest.mock("../../models/productModel", () => ({}), { virtual: true });
+
+const { getSingleOrder } = require("../../controllers/orderController");
+
+describe("getSingleOrder Controller", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {
+      params: { id: "orderId123" },
+      user: { _id: "userA_ID", role: "user", name: "User A", email: "usera@example.com" },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("should fail (404) when order is not found", async () => {
+    // Mock Order.findById to return null via lean()
+    const mockLean = jest.fn().mockResolvedValue(null);
+    Order.findById.mockReturnValue({ lean: mockLean });
+
+    await getSingleOrder(req, res, next);
+
+    expect(Order.findById).toHaveBeenCalledWith("orderId123");
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+    expect(next.mock.calls[0][0].message).toBe("order not found with this id");
+  });
+
+  it("should pass errors from DB to next", async () => {
+    const dbError = new Error("Database error");
+    const mockLean = jest.fn().mockRejectedValue(dbError);
+    Order.findById.mockReturnValue({ lean: mockLean });
+
+    await getSingleOrder(req, res, next);
+
+    expect(Order.findById).toHaveBeenCalledWith("orderId123");
+    expect(next).toHaveBeenCalledWith(dbError);
+  });
+
+  it("should successfully retrieve an order", async () => {
+    const mockOrder = {
+      _id: "orderId123",
+      user: "userA_ID",
+      totalPrice: 100,
+    };
+
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    Order.findById.mockReturnValue({ lean: mockLean });
+
+    await getSingleOrder(req, res, next);
+
+    expect(Order.findById).toHaveBeenCalledWith("orderId123");
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      order: {
+        _id: "orderId123",
+        user: {
+          _id: "userA_ID",
+          name: "User A",
+          email: "usera@example.com",
+        },
+        totalPrice: 100,
+      },
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `getSingleOrder` method in `backend/controllers/orderController.js` lacked direct unit test coverage for its basic read and error operations. Although an existing security-focused test (`security_getSingleOrder_IDOR.test.js`) covered IDOR aspects, it did not purely test standard model operations and simple DB failures.
📊 **Coverage:** Created `orderController_getSingleOrder.test.js` to cover three main paths:
1. `should successfully retrieve an order` (simulating a matched order user and successful response parsing).
2. `should fail (404) when order is not found` (testing the explicit `!order` code path).
3. `should pass errors from DB to next` (ensuring the `catchAsyncErrors` wrapper propagates exceptions properly).
✨ **Result:** Improved baseline unit test coverage for the core `orderController` get functionality, ensuring that any future refactors on standard order reads have an immediate regression check.

---
*PR created automatically by Jules for task [15381578620727572535](https://jules.google.com/task/15381578620727572535) started by @parilsanghvi*