### PR TITLE
🎨 Palette: Add accessibility labels and disable states to UpdateProduct form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,6 @@
 **Learning:** Found `<input type="submit">` being used for search forms. While functional, it limits styling options (like adding an inner icon) and is less semantically clear than `<button type="submit">`.
 **Action:** When working on search interfaces or forms, proactively convert `<input type="submit">` to `<button type="submit">` to allow for richer internal content (like icons or loading spinners) and better semantic meaning. Ensure associated tests querying by `getByDisplayValue` are updated to `getByRole('button')`.
 
+## 2025-06-06 - Form Disabled State Consolidation
+**Learning:** Found that the `UpdateProduct` form had a submit button that was correctly disabled during loading, but the input fields, textarea, and select dropdown were still active. This allowed users to modify form values while a submission was already in progress, potentially leading to race conditions or incorrect data being sent if the submission failed and they resubmitted.
+**Action:** When working on async forms, ensure the `disabled={loading}` state is applied uniformly to ALL interactive form elements (inputs, textareas, selects), not just the submit button.

--- a/frontend/src/component/Admin/UpdateProduct.jsx
+++ b/frontend/src/component/Admin/UpdateProduct.jsx
@@ -161,8 +161,10 @@ const UpdateProduct = () => {
             <input
               type="text"
               placeholder="Product Name"
+              aria-label="Product Name"
               required
               value={name}
+              disabled={loading}
               onChange={(e) => setName(e.target.value)}
             />
           </div>
@@ -171,9 +173,11 @@ const UpdateProduct = () => {
             <input
               type="number"
               placeholder="Price"
+              aria-label="Price"
               required
               onChange={(e) => setPrice(e.target.value)}
               value={price}
+              disabled={loading}
             />
           </div>
 
@@ -182,10 +186,12 @@ const UpdateProduct = () => {
 
             <textarea
               placeholder="Product Description"
+              aria-label="Product Description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               cols="30"
               rows="1"
+              disabled={loading}
             ></textarea>
           </div>
 
@@ -193,7 +199,9 @@ const UpdateProduct = () => {
             <AccountTreeIcon />
             <select
               value={category}
+              aria-label="Category"
               onChange={(e) => setCategory(e.target.value)}
+              disabled={loading}
             >
               <option value="">Choose Category</option>
               {categories.map((cate) => (
@@ -209,9 +217,11 @@ const UpdateProduct = () => {
             <input
               type="number"
               placeholder="Stock"
+              aria-label="Stock"
               required
               onChange={(e) => setStock(e.target.value)}
               value={stock}
+              disabled={loading}
             />
           </div>
 
@@ -219,9 +229,11 @@ const UpdateProduct = () => {
             <input
               type="file"
               name="avatar"
+              aria-label="Product Images"
               accept="image/*"
               onChange={updateProductImagesChange}
               multiple
+              disabled={loading}
             />
           </div>
 
@@ -259,7 +271,7 @@ const UpdateProduct = () => {
           <button
             id="createProductBtn"
             type="submit"
-            disabled={loading ? true : false}
+            disabled={loading}
             className="primary-btn"
             style={{ marginTop: '2rem' }}
           >


### PR DESCRIPTION
💡 **What:** Added comprehensive `aria-label`s and universal `disabled={loading}` states to all fields in the `UpdateProduct` form component. Cleaned up the submit button disabled logic.
🎯 **Why:** To improve screen reader accessibility by providing context for inputs that lacked explicit labels, and to prevent users from modifying field data while an async update operation is actively processing.
📸 **Before/After:** Form inputs lacked `aria-label`s and remained active during submission. Now they have explicit accessible names and are locked when `loading` is true.
♿ **Accessibility:** Added `aria-label` to Product Name, Price, Product Description, Category, Stock, and Product Images inputs. Improved keyboard and screen reader interaction by enforcing a read-only state during processing.

---
*PR created automatically by Jules for task [261796830126239241](https://jules.google.com/task/261796830126239241) started by @parilsanghvi*