### PR TITLE
🧹 [code health] Remove false-positive "Security Fix" keyword from test descriptions

### DIFF
--- a/backend/tests/unit/apifeatures_security.test.js
+++ b/backend/tests/unit/apifeatures_security.test.js
@@ -25,7 +25,7 @@ describe('Apifeatures Security (Regex Injection)', () => {
         expect(findArgs.$text).toHaveProperty('$search', '(');
     });
 
-    it('should escape regex characters in category filter (Security Fix)', () => {
+    it('should escape regex characters in category filter', () => {
         const querystr = { category: '(' };
         const apiFeatures = new Apifeatures(mockQuery, querystr);
 
@@ -34,7 +34,7 @@ describe('Apifeatures Security (Regex Injection)', () => {
         expect(mockQuery.find).toHaveBeenCalled();
         const findArgs = mockQuery.find.mock.calls[0][0];
 
-        // This confirms the fix: the regex is escaped
+        // This confirms the regex is escaped
         expect(findArgs).toHaveProperty('category');
         expect(findArgs.category).toHaveProperty('$regex');
         expect(findArgs.category.$regex).toBe('\\(');


### PR DESCRIPTION
🎯 **What:** Reworded the test description and comments in `backend/tests/unit/apifeatures_security.test.js` to remove the exact phrase "Security Fix" and "the fix:".
💡 **Why:** Automated security and issue scanners (or TODO trackers) were erroneously flagging the word "fix" as a pending action item (e.g., a TODO ticket), even though the security fix is already complete and successfully tested by the associated code block.
✅ **Verification:** Ran the full backend test suite (`pnpm run test:backend`) which executed and passed correctly. The test itself remains structurally intact and functions properly.
✨ **Result:** Future automated parses will no longer flag this specific test as a pending security patch or actionable TODO item.

---
*PR created automatically by Jules for task [6843409228134047313](https://jules.google.com/task/6843409228134047313) started by @parilsanghvi*