### PR TITLE
🧹 [Refactor createThunkHandler in userSlice.js]

### DIFF
--- a/frontend/src/__tests__/slices/userSlice.test.js
+++ b/frontend/src/__tests__/slices/userSlice.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer, {
-    createThunkHandler,
     clearErrors,
     updateProfileReset,
     updatePasswordReset,
@@ -44,56 +43,6 @@ describe('userSlice', () => {
     });
 
     describe('createThunkHandler', () => {
-        it('should return the result of the async function on success', async () => {
-            const mockAsyncFunction = vi.fn().mockResolvedValue('success data');
-            const thunkAPI = { rejectWithValue: vi.fn() };
-            const arg = { id: 1 };
-
-            const handler = createThunkHandler(mockAsyncFunction);
-            const result = await handler(arg, thunkAPI);
-
-            expect(mockAsyncFunction).toHaveBeenCalledWith(arg, thunkAPI);
-            expect(result).toBe('success data');
-            expect(thunkAPI.rejectWithValue).not.toHaveBeenCalled();
-        });
-
-        it('should return rejectWithValue with response.data.message on API error', async () => {
-            const mockAsyncFunction = vi.fn().mockRejectedValue({
-                response: { data: { message: 'API error message' } }
-            });
-            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
-
-            const handler = createThunkHandler(mockAsyncFunction);
-            const result = await handler(null, thunkAPI);
-
-            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('API error message');
-            expect(result).toBe('rejected: API error message');
-        });
-
-        it('should return rejectWithValue with error.message on standard error', async () => {
-            const mockAsyncFunction = vi.fn().mockRejectedValue(new Error('Network error'));
-            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
-
-            const handler = createThunkHandler(mockAsyncFunction);
-            const result = await handler(null, thunkAPI);
-
-            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('Network error');
-            expect(result).toBe('rejected: Network error');
-        });
-
-        it('should return rejectWithValue with default message when error has no standard message fields', async () => {
-            const mockAsyncFunction = vi.fn().mockRejectedValue({});
-            const thunkAPI = { rejectWithValue: vi.fn().mockImplementation(msg => `rejected: ${msg}`) };
-
-            const handler = createThunkHandler(mockAsyncFunction);
-            const result = await handler(null, thunkAPI);
-
-            expect(thunkAPI.rejectWithValue).toHaveBeenCalledWith('An error occurred');
-            expect(result).toBe('rejected: An error occurred');
-        });
-    });
-
-    describe('synchronous reducers', () => {
         it('clearErrors should reset error', () => {
             const state = { ...initialState, error: 'Auth error' };
             expect(userReducer(state, clearErrors()).error).toBeNull();

--- a/frontend/src/features/userSlice.js
+++ b/frontend/src/features/userSlice.js
@@ -1,16 +1,7 @@
 import { createSlice, createAsyncThunk, isAnyOf } from "@reduxjs/toolkit";
 import axios from "axios";
 import { API_BASE_URL } from "../config";
-
-// Custom helper to standardize thunk error handling
-export const createThunkHandler = (asyncFunction) => async (arg, thunkAPI) => {
-    try {
-        return await asyncFunction(arg, thunkAPI);
-    } catch (error) {
-        const errorMessage = error.response?.data?.message || error.message || "An error occurred";
-        return thunkAPI.rejectWithValue(errorMessage);
-    }
-};
+import { createThunkHandler } from "../utils/thunkHandler";
 
 // Async Thunks
 export const login = createAsyncThunk(


### PR DESCRIPTION
🎯 **What:**
Refactored the `createThunkHandler` function in `frontend/src/features/userSlice.js`. It was previously defined inline within `userSlice.js` and had redundant test coverage in `userSlice.test.js`. Now, `userSlice.js` imports the centralized utility function from `../utils/thunkHandler.js`, and its redundant tests have been removed since `frontend/src/__tests__/utils/thunkHandler.test.js` completely covers it.

💡 **Why:**
This improves code maintainability and readability. By extracting the utility function to a shared location, we prevent code duplication and centralize error handling logic for Redux thunks. Tests are also centralized to their respective unit file rather than cluttering slice tests.

✅ **Verification:**
Ran the full frontend test suite locally with `cd frontend && pnpm run test`. All 316 tests pass, including the 4 dedicated tests in `thunkHandler.test.js` and the remaining 23 tests in `userSlice.test.js`. No regressions were introduced.

✨ **Result:**
The `userSlice.js` file is cleaner, smaller, and relies on shared utilities. Code health and DRY principles are maintained.

---
*PR created automatically by Jules for task [6135094472329427614](https://jules.google.com/task/6135094472329427614) started by @parilsanghvi*