### PR TITLE
🧪 [testing improvement] Fix broken mocks in security password leak tests

### DIFF
--- a/backend/tests/security_password_leak.test.js
+++ b/backend/tests/security_password_leak.test.js
@@ -1,6 +1,7 @@
-const { loginUser, registerUser } = require("../controllers/userController");
+const { loginUser, registerUser, updatePassword } = require("../controllers/userController");
 const User = require("../models/userModel");
 const sendToken = require("../utils/jwtToken");
+
 jest.mock("../utils/jwtToken");
 jest.mock("../models/userModel");
 jest.mock("../utils/errorhandler");
@@ -8,7 +9,10 @@ jest.mock("cloudinary", () => ({
     v2: {
         uploader: {
             destroy: jest.fn(),
-            upload: jest.fn()
+            upload: jest.fn().mockResolvedValue({
+                public_id: "mock_id",
+                secure_url: "mock_url"
+            })
         }
     }
 }));
@@ -48,11 +52,6 @@ describe("Security: Password Hash Leak", () => {
     });
 
     it("should not pass user with password to sendToken in registerUser", async () => {
-        const cloudinary = require("cloudinary");
-        cloudinary.v2.uploader.upload.mockResolvedValue({
-            public_id: "id",
-            secure_url: "url"
-        });
         req.body = { name: "test", email: "test@test.com", password: "password123", avatar: "base64" };
         const mockUser = {
             _id: "123",
@@ -69,7 +68,6 @@ describe("Security: Password Hash Leak", () => {
     });
 
     it("should not pass user with password to sendToken in updatePassword", async () => {
-        const { updatePassword } = require("../controllers/userController");
         req.user = { _id: "123" };
         req.body = { oldPassword: "oldpassword", newPassword: "newpassword", confirmPassword: "newpassword" };
         const mockUser = {


### PR DESCRIPTION
🎯 **What:**
- Fixed `cloudinary.v2.uploader.upload` mock configuration in `security_password_leak.test.js` to ensure the simulated response yields `public_id` and `secure_url`.
- Corrected test cases so that `registerUser` properly executes and `sendToken` mock receives the expected arguments without encountering TypeError exceptions.

📊 **Coverage:**
- Ensures that the test cases verifying password hash stripping correctly validate the logic without failing midway through the setup.

✨ **Result:**
- Verified that the codebase correctly omits `user.password` when emitting API responses via `sendToken`.
- Tests pass cleanly and baseline security assertions are solid.

---
*PR created automatically by Jules for task [10984392697859767524](https://jules.google.com/task/10984392697859767524) started by @parilsanghvi*