### PR TITLE
🎨 Palette: Add accessibility and loading state to Admin forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,6 @@
 ## 2025-06-06 - Form Disabled State Consolidation
 **Learning:** Found that the `UpdateProduct` form had a submit button that was correctly disabled during loading, but the input fields, textarea, and select dropdown were still active. This allowed users to modify form values while a submission was already in progress, potentially leading to race conditions or incorrect data being sent if the submission failed and they resubmitted.
 **Action:** When working on async forms, ensure the `disabled={loading}` state is applied uniformly to ALL interactive form elements (inputs, textareas, selects), not just the submit button.
+## 2025-06-07 - Admin Forms Accessibility and Disabled States
+**Learning:** Found that internal admin forms (`NewProduct` and `UpdateUser`) lacked `aria-label`s on their input fields, relying entirely on placeholders, which causes issues for screen reader users managing the store backend. Additionally, while the submit buttons handled loading state correctly, the input fields remained active during submission.
+**Action:** When working on admin dashboard forms, ensure accessibility standards are applied just as rigorously as the public storefront. Add `aria-label` to all inputs, textareas, and selects lacking explicit labels, and uniformly apply `disabled={loading}` to all interactive form elements during submission.

--- a/frontend/src/component/Admin/NewProduct.jsx
+++ b/frontend/src/component/Admin/NewProduct.jsx
@@ -106,9 +106,11 @@ const NewProduct = () => {
             <input
               type="text"
               placeholder="Product Name"
+              aria-label="Product Name"
               required
               value={name}
               onChange={(e) => setName(e.target.value)}
+              disabled={loading}
             />
           </div>
           <div>
@@ -116,8 +118,10 @@ const NewProduct = () => {
             <input
               type="number"
               placeholder="Price"
+              aria-label="Price"
               required
               onChange={(e) => setPrice(e.target.value)}
+              disabled={loading}
             />
           </div>
 
@@ -126,16 +130,22 @@ const NewProduct = () => {
 
             <textarea
               placeholder="Product Description"
+              aria-label="Product Description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               cols="30"
               rows="1"
+              disabled={loading}
             ></textarea>
           </div>
 
           <div>
             <AccountTreeIcon />
-            <select onChange={(e) => setCategory(e.target.value)}>
+            <select
+              onChange={(e) => setCategory(e.target.value)}
+              aria-label="Category"
+              disabled={loading}
+            >
               <option value="">Choose Category</option>
               {categories.map((cate) => (
                 <option key={cate} value={cate}>
@@ -150,8 +160,10 @@ const NewProduct = () => {
             <input
               type="number"
               placeholder="Stock"
+              aria-label="Stock"
               required
               onChange={(e) => setStock(e.target.value)}
+              disabled={loading}
             />
           </div>
 
@@ -160,8 +172,10 @@ const NewProduct = () => {
               type="file"
               name="avatar"
               accept="image/*"
+              aria-label="Product Images"
               onChange={createProductImagesChange}
               multiple
+              disabled={loading}
             />
           </div>
 

--- a/frontend/src/component/Admin/UpdateUser.jsx
+++ b/frontend/src/component/Admin/UpdateUser.jsx
@@ -92,9 +92,11 @@ const UpdateUser = () => {
               <input
                 type="text"
                 placeholder="Name"
+                aria-label="Name"
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
+                disabled={updateLoading}
               />
             </div>
             <div>
@@ -102,15 +104,22 @@ const UpdateUser = () => {
               <input
                 type="email"
                 placeholder="Email"
+                aria-label="Email"
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
+                disabled={updateLoading}
               />
             </div>
 
             <div>
               <VerifiedUserIcon />
-              <select value={role} onChange={(e) => setRole(e.target.value)}>
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                aria-label="Role"
+                disabled={updateLoading}
+              >
                 <option value="">Choose Role</option>
                 <option value="admin">Admin</option>
                 <option value="user">User</option>


### PR DESCRIPTION
💡 What: Added aria-labels and disabled states during loading for NewProduct and UpdateUser forms.
🎯 Why: Ensures inputs have explicit accessible names and prevents mid-submission modifications.
📸 Before/After: N/A
♿ Accessibility: Screen readers now announce input purposes instead of relying on placeholders.

---
*PR created automatically by Jules for task [2631460641657749410](https://jules.google.com/task/2631460641657749410) started by @parilsanghvi*