### PR TITLE
🎨 Palette: Add aria-labels to admin form inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,6 @@
 ## 2025-06-06 - Form Disabled State Consolidation
 **Learning:** Found that the `UpdateProduct` form had a submit button that was correctly disabled during loading, but the input fields, textarea, and select dropdown were still active. This allowed users to modify form values while a submission was already in progress, potentially leading to race conditions or incorrect data being sent if the submission failed and they resubmitted.
 **Action:** When working on async forms, ensure the `disabled={loading}` state is applied uniformly to ALL interactive form elements (inputs, textareas, selects), not just the submit button.
+## 2026-06-11 - Admin Form Inputs Accessibility
+**Learning:** Discovered multiple admin form inputs relying solely on placeholders without accessible names, making them difficult for screen reader users to interact with.
+**Action:** Always provide explicit accessible names using `aria-label` for form inputs without visible `<label>` elements, especially in data-entry heavy forms like admin panels.

--- a/frontend/src/component/Admin/NewProduct.jsx
+++ b/frontend/src/component/Admin/NewProduct.jsx
@@ -106,6 +106,7 @@ const NewProduct = () => {
             <input
               type="text"
               placeholder="Product Name"
+              aria-label="Product Name"
               required
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -116,6 +117,7 @@ const NewProduct = () => {
             <input
               type="number"
               placeholder="Price"
+              aria-label="Price"
               required
               onChange={(e) => setPrice(e.target.value)}
             />
@@ -126,6 +128,7 @@ const NewProduct = () => {
 
             <textarea
               placeholder="Product Description"
+              aria-label="Product Description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               cols="30"
@@ -135,7 +138,7 @@ const NewProduct = () => {
 
           <div>
             <AccountTreeIcon />
-            <select onChange={(e) => setCategory(e.target.value)}>
+            <select aria-label="Category" onChange={(e) => setCategory(e.target.value)}>
               <option value="">Choose Category</option>
               {categories.map((cate) => (
                 <option key={cate} value={cate}>
@@ -150,6 +153,7 @@ const NewProduct = () => {
             <input
               type="number"
               placeholder="Stock"
+              aria-label="Stock"
               required
               onChange={(e) => setStock(e.target.value)}
             />
@@ -159,6 +163,7 @@ const NewProduct = () => {
             <input
               type="file"
               name="avatar"
+              aria-label="Product Images"
               accept="image/*"
               onChange={createProductImagesChange}
               multiple

--- a/frontend/src/component/Admin/ProductReviews.jsx
+++ b/frontend/src/component/Admin/ProductReviews.jsx
@@ -145,6 +145,7 @@ const ProductReviews = () => {
             <input
               type="text"
               placeholder="Product Id"
+              aria-label="Product Id"
               required
               value={productId}
               onChange={(e) => setProductId(e.target.value)}

--- a/frontend/src/component/Admin/UpdateUser.jsx
+++ b/frontend/src/component/Admin/UpdateUser.jsx
@@ -92,6 +92,7 @@ const UpdateUser = () => {
               <input
                 type="text"
                 placeholder="Name"
+                aria-label="Name"
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -102,6 +103,7 @@ const UpdateUser = () => {
               <input
                 type="email"
                 placeholder="Email"
+                aria-label="Email"
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -110,7 +112,7 @@ const UpdateUser = () => {
 
             <div>
               <VerifiedUserIcon />
-              <select value={role} onChange={(e) => setRole(e.target.value)}>
+              <select aria-label="Role" value={role} onChange={(e) => setRole(e.target.value)}>
                 <option value="">Choose Role</option>
                 <option value="admin">Admin</option>
                 <option value="user">User</option>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple form fields (inputs, textareas, selects) across admin components (`NewProduct.jsx`, `UpdateUser.jsx`, `ProductReviews.jsx`).
🎯 Why: These forms previously relied on placeholders or surrounding context, which is poor for screen reader accessibility. Adding explicit accessible names makes the forms usable for assistive technologies.
📸 Before/After: Visuals remain unchanged, but the accessibility tree now properly exposes input purposes.
♿ Accessibility: Improved screen reader support for key admin data entry and management forms.

---
*PR created automatically by Jules for task [15796661327178712440](https://jules.google.com/task/15796661327178712440) started by @parilsanghvi*