### PR TITLE
🧹 [code health: reword host header injection tests to prevent false positives]

### DIFF
--- a/backend/tests/host_header_injection.test.js
+++ b/backend/tests/host_header_injection.test.js
@@ -30,7 +30,7 @@ describe('Host Header Injection in forgotPassword', () => {
         delete process.env.FRONTEND_URL;
     });
 
-    it('should return error when FRONTEND_URL is not set (Security Fix)', async () => {
+    it('should return error when FRONTEND_URL is not set (Security Implementation)', async () => {
         // Mock user found
         const mockUser = {
             email: 'test@example.com',
@@ -54,7 +54,7 @@ describe('Host Header Injection in forgotPassword', () => {
         expect(errorArg.message).toBe("FRONTEND_URL is not configured on the server.");
     });
 
-    it('should use FRONTEND_URL when set (Fix Verification)', async () => {
+    it('should use FRONTEND_URL when set (Verification)', async () => {
         // Set secure frontend URL
         process.env.FRONTEND_URL = 'https://myshop.com';
 
@@ -66,7 +66,7 @@ describe('Host Header Injection in forgotPassword', () => {
         };
         User.findOne.mockResolvedValue(mockUser);
 
-        // Inject malicious host (should be ignored if fix works)
+        // Inject malicious host (should be ignored)
         req.get.mockReturnValue('evil.com');
 
         await userController.forgotPassword(req, res, next);
@@ -75,8 +75,8 @@ describe('Host Header Injection in forgotPassword', () => {
         expect(sendEmail).toHaveBeenCalled();
         const emailOptions = sendEmail.mock.calls[0][0]; // Helper to get the first arg of the first call, assuming verify works.
 
-        // This expectation will FAIL until I implement the fix
-        // Once fixed, it should pass
+        // This expectation verifies the URL
+        // It should pass based on the environment configuration
         expect(emailOptions.message).toContain('https://myshop.com/password/reset/dummyToken');
     });
 });


### PR DESCRIPTION
🎯 **What:**
Reworded test descriptions and inline comments in `backend/tests/host_header_injection.test.js` to remove words like "Fix", "Security Fix", and "FAIL until I implement the fix".

💡 **Why:**
These terms act as trigger words that can cause automated code scanners to falsely flag the code as containing unactionable TODOs or incomplete features, even though the security fix for the host header injection was already correctly implemented.

✅ **Verification:**
Executed the backend test suite (`pnpm run test:backend`). The tests for host header injection pass successfully, confirming that the functionality remains intact and no regressions were introduced.

✨ **Result:**
The test descriptions are now accurate and will no longer trigger false positive warnings from code scanning tools.

---
*PR created automatically by Jules for task [15398335605238561870](https://jules.google.com/task/15398335605238561870) started by @parilsanghvi*