### PR TITLE
🧪 [testing improvement] Add unit tests for uploadImage utility

### DIFF
--- a/backend/tests/unit/imageUpload.test.js
+++ b/backend/tests/unit/imageUpload.test.js
@@ -1,0 +1,67 @@
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            upload_stream: jest.fn(),
+            upload: jest.fn(),
+        },
+    },
+}));
+
+const { uploadImage } = require('../../utils/imageUpload');
+const cloudinary = require('cloudinary');
+
+describe('uploadImage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should upload a buffer successfully', async () => {
+        const file = { buffer: Buffer.from('test') };
+        cloudinary.v2.uploader.upload_stream.mockImplementation((options, cb) => {
+            return {
+                end: () => cb(null, { public_id: 'buf_id', secure_url: 'http://buf.url' })
+            };
+        });
+
+        const result = await uploadImage(file, 'test_folder');
+        expect(result).toEqual({ public_id: 'buf_id', url: 'http://buf.url' });
+        expect(cloudinary.v2.uploader.upload_stream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle buffer upload error', async () => {
+        const file = { buffer: Buffer.from('test') };
+        const uploadError = new Error('upload failed');
+        cloudinary.v2.uploader.upload_stream.mockImplementation((options, cb) => {
+            return {
+                end: () => cb(uploadError, null)
+            };
+        });
+
+        await expect(uploadImage(file, 'test_folder')).rejects.toThrow('upload failed');
+    });
+
+    it('should upload a string successfully', async () => {
+        const file = 'data:image/jpeg;base64,test';
+        cloudinary.v2.uploader.upload.mockResolvedValue({
+            public_id: 'str_id',
+            secure_url: 'http://str.url'
+        });
+
+        const result = await uploadImage(file, 'test_folder');
+        expect(result).toEqual({ public_id: 'str_id', url: 'http://str.url' });
+        expect(cloudinary.v2.uploader.upload).toHaveBeenCalledWith(file, expect.objectContaining({ folder: 'test_folder' }));
+    });
+
+    it('should handle string upload error', async () => {
+        const file = 'data:image/jpeg;base64,test';
+        const uploadError = new Error('string upload failed');
+        cloudinary.v2.uploader.upload.mockRejectedValue(uploadError);
+
+        await expect(uploadImage(file, 'test_folder')).rejects.toThrow('string upload failed');
+    });
+
+    it('should reject invalid file format', async () => {
+        const file = { invalid: 'format' };
+        await expect(uploadImage(file, 'test_folder')).rejects.toThrow('Invalid file format. Expected buffer or string.');
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests to cover the untested `uploadImage` utility function in `backend/utils/imageUpload.js`.
📊 **Coverage:** The tests now completely mock Cloudinary's v2 API and cover:
  - Successful image buffer uploads via `upload_stream`.
  - Error handling during buffer uploads.
  - Successful string (base64/URL) uploads via `upload`.
  - Error handling during string uploads.
  - Edge cases such as rejecting invalid file formats (neither buffer nor string).
✨ **Result:** Improved codebase test reliability and safety net coverage by properly verifying Cloudinary interaction logic and its error behaviors.

---
*PR created automatically by Jules for task [11436254090922385984](https://jules.google.com/task/11436254090922385984) started by @parilsanghvi*