### PR TITLE
🧹 [Reword misleading fix comment in forgot password test]

### DIFF
--- a/backend/tests/security_forgot_password.test.js
+++ b/backend/tests/security_forgot_password.test.js
@@ -91,8 +91,7 @@ describe('Security: Forgot Password Enumeration', () => {
             .post('/api/v1/password/forgot')
             .send({ email: 'nonexistent@example.com' });
 
-        // This assertion is expected to FAIL before the fix
-        // Currently it returns 404
+        // Verify the generic success response to prevent email enumeration
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
         expect(res.body.message).toBe('If your email is registered, you will receive a password reset link shortly.');


### PR DESCRIPTION
🧹 [Reword misleading fix comment in forgot password test]

🎯 **What:** Reworded a misleading comment in `backend/tests/security_forgot_password.test.js` that falsely claimed an assertion was expected to fail before a fix.

💡 **Why:** The comment falsely flagged the code as needing a fix, potentially triggering automated scanners or confusing developers, despite the underlying email enumeration vulnerability already being successfully mitigated in the application logic (it properly returns a generic success message for both valid and invalid emails).

✅ **Verification:** Verified that the relevant test (`pnpm run test:backend -- backend/tests/security_forgot_password.test.js`) and the broader test suite (`pnpm run test:backend`) pass without regression.

✨ **Result:** The misleading comment has been removed, preventing future confusion while maintaining the test's coverage of the email enumeration security fix.

---
*PR created automatically by Jules for task [15046256925982552918](https://jules.google.com/task/15046256925982552918) started by @parilsanghvi*