### PR TITLE
🧪 Add missing error test for getSingleOrder status 404

### DIFF
--- a/backend/tests/unit/orderController_getSingleOrder.test.js
+++ b/backend/tests/unit/orderController_getSingleOrder.test.js
@@ -43,6 +43,29 @@ describe("getSingleOrder Controller", () => {
     expect(next.mock.calls[0][0].message).toBe("order not found with this id");
   });
 
+
+  it("should fail (404) when user accesses another user's order and is not admin", async () => {
+    // Setup request with user different from order owner and not admin
+    req.user._id = "userB_ID";
+    req.user.role = "user";
+
+    const mockOrder = {
+      _id: "orderId123",
+      user: "userA_ID", // Different user
+      totalPrice: 100,
+    };
+
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    Order.findById.mockReturnValue({ lean: mockLean });
+
+    await getSingleOrder(req, res, next);
+
+    expect(Order.findById).toHaveBeenCalledWith("orderId123");
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+    expect(next.mock.calls[0][0].message).toBe("order not found with this id");
+  });
+
   it("should pass errors from DB to next", async () => {
     const dbError = new Error("Database error");
     const mockLean = jest.fn().mockRejectedValue(dbError);


### PR DESCRIPTION
🎯 **What:** Missing error test in getSingleOrder for status 404 IDOR check
📊 **Coverage:** Tested that a non-admin user cannot access another user's order
✨ **Result:** Increased test coverage for IDOR security checks in order retrieval

---
*PR created automatically by Jules for task [6688431296818445324](https://jules.google.com/task/6688431296818445324) started by @parilsanghvi*