### PR TITLE
🧪 [add test for 400 error on missing payment info in newOrder]

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -213,7 +213,7 @@ describe('newOrder Controller', () => {
         expect(mockNext.mock.calls[0][0].message).toContain('Total price mismatch detected. Please refresh and try again.');
     });
 
-    it('should fail if paymentInfo is missing or lacks an ID', async () => {
+    it('should fail if paymentInfo lacks an ID', async () => {
         const req = {
             body: getValidReqBody(),
             user: testUser
@@ -224,6 +224,21 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment Information is missing');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
+    });
+
+    it('should fail if paymentInfo is completely missing', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+        delete req.body.paymentInfo;
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Payment Information is missing');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail if stripe payment intent status is not succeeded', async () => {


### PR DESCRIPTION
🎯 **What:** Addressed testing gap for status 400 error when `paymentInfo` is missing in `newOrder` controller.
📊 **Coverage:** Covered edge case where `paymentInfo` object or `paymentInfo.id` is completely missing from request body.
✨ **Result:** Improved test reliability by verifying the exact error message and status code.

---
*PR created automatically by Jules for task [9817477457951798498](https://jules.google.com/task/9817477457951798498) started by @parilsanghvi*