### PR TITLE
🧪 [Add missing error test for getSingleOrder 404]

### DIFF
--- a/backend/tests/unit/orderController_getSingleOrder.test.js
+++ b/backend/tests/unit/orderController_getSingleOrder.test.js
@@ -43,6 +43,24 @@ describe("getSingleOrder Controller", () => {
     expect(next.mock.calls[0][0].message).toBe("order not found with this id");
   });
 
+  it("should fail (404) when order belongs to a different user and requester is not admin", async () => {
+    const mockOrder = {
+      _id: "orderId123",
+      user: "different_user_id",
+      totalPrice: 100,
+    };
+
+    const mockLean = jest.fn().mockResolvedValue(mockOrder);
+    Order.findById.mockReturnValue({ lean: mockLean });
+
+    await getSingleOrder(req, res, next);
+
+    expect(Order.findById).toHaveBeenCalledWith("orderId123");
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+    expect(next.mock.calls[0][0].statusCode).toBe(404);
+    expect(next.mock.calls[0][0].message).toBe("order not found with this id");
+  });
+
   it("should pass errors from DB to next", async () => {
     const dbError = new Error("Database error");
     const mockLean = jest.fn().mockRejectedValue(dbError);


### PR DESCRIPTION
🎯 **What:** The testing gap in the `getSingleOrder` controller where the 404 error branch for the IDOR security check was not explicitly tested has been addressed.
📊 **Coverage:** A test scenario is now covered where a user attempts to access an order that does not belong to them and they are not an admin.
✨ **Result:** Increased test coverage for error conditions and explicitly verifies the security logic that prevents IDOR vulnerabilities.

---
*PR created automatically by Jules for task [13987001311560971511](https://jules.google.com/task/13987001311560971511) started by @parilsanghvi*