### PR TITLE
🧪 [testing improvement] Add missing error test in newOrder for status 400

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -224,6 +224,21 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment Information is missing');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
+    });
+
+    it('should fail if paymentInfo is entirely missing', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+        delete req.body.paymentInfo;
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Payment Information is missing');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail if stripe payment intent status is not succeeded', async () => {


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `orderController_newOrder.test.js` to ensure the controller correctly handles completely missing `paymentInfo` and properly returns a 400 status code with the correct error message. Also updated the existing test for missing `paymentInfo.id` to verify its status code.
📊 **Coverage:** The tests now comprehensively cover both `!paymentInfo` and `!paymentInfo.id` cases under the security fix block inside `newOrder`, verifying both the error message and the HTTP 400 status code.
✨ **Result:** Improved test coverage and reliability for error handling branches in payment verification.

---
*PR created automatically by Jules for task [14856907752021978031](https://jules.google.com/task/14856907752021978031) started by @parilsanghvi*