### PR TITLE
🧪 [testing improvement] Add error test for product not found 404 in newOrder

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -148,6 +148,28 @@ describe('newOrder Controller', () => {
         expect(mockNext.mock.calls[0][0].message).toContain('Invalid quantity for product');
     });
 
+    it('should fail with status 404 if product is not found (using mocking)', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+
+        // Mock Product.find to return empty array
+        const findSpy = jest.spyOn(Product, 'find').mockReturnValue({
+            select: jest.fn().mockReturnValue({
+                lean: jest.fn().mockResolvedValue([])
+            })
+        });
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Product not found');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(404);
+
+        findSpy.mockRestore();
+    });
+
     it('should fail if product is not found', async () => {
         const req = {
             body: getValidReqBody(),


### PR DESCRIPTION
🎯 **What:** Added an isolated unit test using mocking to explicitly verify that the `newOrder` controller correctly triggers a 404 status error when a product is not found in the database.
📊 **Coverage:** Specifically tests the error handling branch where `productMap.get()` returns undefined after a `Product.find()` lookup, asserting that `mockNext` receives the correct `ErrorHandler` instance with a 404 status.
✨ **Result:** Improved test reliability and explicit coverage of edge case error routing for the newOrder workflow.

---
*PR created automatically by Jules for task [5147481389897932217](https://jules.google.com/task/5147481389897932217) started by @parilsanghvi*