### PR TITLE
🧪 Add error test for sendEmail in utils

### DIFF
--- a/backend/tests/unit/utils.test.js
+++ b/backend/tests/unit/utils.test.js
@@ -2,12 +2,14 @@ const sendEmail = require('../../utils/sendEmail');
 // We need to mock 'resend' package
 const { Resend } = require('resend');
 
+const mockSend = jest.fn().mockResolvedValue({ id: 'test_id' });
+
 jest.mock('resend', () => {
     return {
         Resend: jest.fn().mockImplementation(() => {
             return {
                 emails: {
-                    send: jest.fn().mockResolvedValue({ id: 'test_id' }),
+                    send: mockSend,
                 },
             };
         }),
@@ -15,6 +17,11 @@ jest.mock('resend', () => {
 });
 
 describe('Utils: sendEmail', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockSend.mockResolvedValue({ id: 'test_id' }); // reset default
+    });
+
     it('should send an email using Resend', async () => {
         const options = {
             email: 'test@example.com',
@@ -28,5 +35,28 @@ describe('Utils: sendEmail', () => {
         expect(Resend).toHaveBeenCalledWith(process.env.RESEND_API_KEY);
         // We can't easily access the instance method unless we spy on it or capture the mock instance.
         // But since we mocked the constructor to return an object with a spy, we can check basic execution.
+        expect(mockSend).toHaveBeenCalledWith({
+            from: 'onboarding@resend.dev',
+            to: options.email,
+            subject: options.subject,
+            text: options.message,
+        });
+    });
+
+    it('should throw an error if email sending fails', async () => {
+        mockSend.mockRejectedValueOnce(new Error('Resend API error'));
+
+        // Suppress console.error for this test to avoid polluting test output
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const options = {
+            email: 'test@example.com',
+            subject: 'Test Subject',
+            message: 'Test Message',
+        };
+
+        await expect(sendEmail(options)).rejects.toThrow('Email sending failed');
+
+        consoleSpy.mockRestore();
     });
 });


### PR DESCRIPTION
🎯 **What:** The `sendEmail` function's error handling (`catch` block) was not covered by any tests. Added a new unit test in `backend/tests/unit/utils.test.js` to simulate an API rejection from Resend and assert that the function correctly catches the error and throws an "Email sending failed" error.
📊 **Coverage:** The entire `sendEmail` utility function is now fully tested, including both the successful happy-path and the error path when the Resend API fails.
✨ **Result:** Improved test reliability and ensured that regressions in the error handling of `sendEmail` will be caught. Additionally improved the existing happy-path test by explicitly asserting the `send` method is called with the correct parameters.

---
*PR created automatically by Jules for task [4456974078469240792](https://jules.google.com/task/4456974078469240792) started by @parilsanghvi*