### PR TITLE
🧪 [Testing Improvement] Add 400 Status Error Test for Payment Replay Attack

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -306,5 +306,6 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment already used');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 });

--- a/backend/tests/security_payment_verification.test.js
+++ b/backend/tests/security_payment_verification.test.js
@@ -148,6 +148,7 @@ describe('Order Security: Payment Verification', () => {
 
         expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(next.mock.calls[0][0].message).toMatch(/Payment already used/);
+        expect(next.mock.calls[0][0].statusCode).toBe(400);
         expect(Order.create).not.toHaveBeenCalled();
     });
 });

--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,0 +1,3 @@
+🎯 **What:** Added tests for the 400 error status code on the payment replay attack condition in the `newOrder` controller.
+📊 **Coverage:** The `Payment already used` ErrorHandler calls now explicitly assert that a 400 status code is returned as expected.
+✨ **Result:** Improved test reliability and ensured that regressions altering this status code will be caught by our CI pipeline.


### PR DESCRIPTION
🎯 **What:** Added tests for the 400 error status code on the payment replay attack condition in the `newOrder` controller.
📊 **Coverage:** The `Payment already used` ErrorHandler calls now explicitly assert that a 400 status code is returned as expected.
✨ **Result:** Improved test reliability and ensured that regressions altering this status code will be caught by our CI pipeline.

---
*PR created automatically by Jules for task [17552534684158186234](https://jules.google.com/task/17552534684158186234) started by @parilsanghvi*