### PR TITLE
🧹 [update test description to prevent scanner false positives]

### DIFF
--- a/backend/tests/unit/apifeatures_security.test.js
+++ b/backend/tests/unit/apifeatures_security.test.js
@@ -25,7 +25,7 @@ describe('Apifeatures Security (Regex Injection)', () => {
         expect(findArgs.$text).toHaveProperty('$search', '(');
     });
 
-    it('should escape regex characters in category filter (Security Fix)', () => {
+    it('should escape regex characters in category filter', () => {
         const querystr = { category: '(' };
         const apiFeatures = new Apifeatures(mockQuery, querystr);
 
@@ -34,7 +34,7 @@ describe('Apifeatures Security (Regex Injection)', () => {
         expect(mockQuery.find).toHaveBeenCalled();
         const findArgs = mockQuery.find.mock.calls[0][0];
 
-        // This confirms the fix: the regex is escaped
+        // This confirms the behavior: the regex is escaped
         expect(findArgs).toHaveProperty('category');
         expect(findArgs.category).toHaveProperty('$regex');
         expect(findArgs.category.$regex).toBe('\\(');


### PR DESCRIPTION
🎯 **What:** Updated test description and inline comment in `apifeatures_security.test.js` to replace the word "fix" with "behavior".

💡 **Why:** An automated code scanner falsely flagged the string "Fix" within a unit test block as an actionable item or unresolved bug. Re-wording the test resolves this false positive.

✅ **Verification:** Ran `pnpm run test:backend` and ensured the test `should escape regex characters in category filter` still passes normally.

✨ **Result:** Test correctly conveys its behavior verification without triggering automated scanners for false positive code tasks.

---
*PR created automatically by Jules for task [6813035894624881235](https://jules.google.com/task/6813035894624881235) started by @parilsanghvi*