### PR TITLE
🧹 [code health improvement] Remove false-positive scanner triggers in tests

### DIFF
--- a/backend/tests/host_header_injection.test.js
+++ b/backend/tests/host_header_injection.test.js
@@ -30,7 +30,7 @@ describe('Host Header Injection in forgotPassword', () => {
         delete process.env.FRONTEND_URL;
     });
 
-    it('should return error when FRONTEND_URL is not set (Security Fix)', async () => {
+    it('should return error when FRONTEND_URL is not set', async () => {
         // Mock user found
         const mockUser = {
             email: 'test@example.com',
@@ -54,7 +54,7 @@ describe('Host Header Injection in forgotPassword', () => {
         expect(errorArg.message).toBe("FRONTEND_URL is not configured on the server.");
     });
 
-    it('should use FRONTEND_URL when set (Fix Verification)', async () => {
+    it('should use FRONTEND_URL when set', async () => {
         // Set secure frontend URL
         process.env.FRONTEND_URL = 'https://myshop.com';
 
@@ -66,7 +66,7 @@ describe('Host Header Injection in forgotPassword', () => {
         };
         User.findOne.mockResolvedValue(mockUser);
 
-        // Inject malicious host (should be ignored if fix works)
+        // Inject malicious host (should be ignored)
         req.get.mockReturnValue('evil.com');
 
         await userController.forgotPassword(req, res, next);
@@ -75,8 +75,6 @@ describe('Host Header Injection in forgotPassword', () => {
         expect(sendEmail).toHaveBeenCalled();
         const emailOptions = sendEmail.mock.calls[0][0]; // Helper to get the first arg of the first call, assuming verify works.
 
-        // This expectation will FAIL until I implement the fix
-        // Once fixed, it should pass
         expect(emailOptions.message).toContain('https://myshop.com/password/reset/dummyToken');
     });
 });


### PR DESCRIPTION
🎯 **What:** Reworded comments and test descriptions in `backend/tests/host_header_injection.test.js` to remove words like 'Fix' and 'FAIL until I implement the fix'.
💡 **Why:** These keywords falsely trigger automated vulnerability/todo scanners, even though the host header injection fix was already correctly implemented.
✅ **Verification:** Ran the backend test suite; the modified host header injection tests passed without issue.
✨ **Result:** Clean scan results without false positives for this file.

---
*PR created automatically by Jules for task [15305434022443914223](https://jules.google.com/task/15305434022443914223) started by @parilsanghvi*