### PR TITLE
🧪 Add error test for invalid quantity in newOrder

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -146,6 +146,21 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Invalid quantity for product');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
+    });
+
+    it('should fail with non-integer quantity', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+        req.body.orderItems[0].quantity = 1.5;
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Invalid quantity for product');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail if product is not found', async () => {


### PR DESCRIPTION
🎯 **What:** The controller logic in `orderController.js` includes an explicit security check rejecting non-integer and less-than-one quantities with a 400 status error, but this error branch was partially untested. Added a specific test case for non-integer quantities and updated the existing test for <= 0 quantities to verify the returned 400 status code.

📊 **Coverage:** The test suite now explicitly covers error paths handling non-integer input quantities (e.g., `1.5`) alongside previously covered 0 or negative quantities, and confirms the `ErrorHandler` provides a 400 status code.

✨ **Result:** Improved overall backend test coverage and reliability for critical security checks during order creation, ensuring malicious or malformed inputs are correctly halted and reported.

---
*PR created automatically by Jules for task [11416627359391567966](https://jules.google.com/task/11416627359391567966) started by @parilsanghvi*