### PR TITLE
🧪 [testing improvement] Add missing error test in newOrder for status 400 on shipping price mismatch

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -200,6 +200,21 @@ describe('newOrder Controller', () => {
         expect(mockNext.mock.calls[0][0].message).toContain('Shipping price mismatch detected. Please refresh and try again.');
     });
 
+    it('should fail if shippingPrice is not a number and verify status 400', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+        req.body.shippingPrice = "invalid";
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Shipping price mismatch detected. Please refresh and try again.');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
+    });
+
+
     it('should fail on totalPrice mismatch', async () => {
         const req = {
             body: getValidReqBody(),


### PR DESCRIPTION
🎯 **What:** The testing gap for missing error test in newOrder for status 400 on invalid shipping price was addressed.
📊 **Coverage:** Covered edge case where `shippingPrice` is NaN, triggering the 400 error path.
✨ **Result:** Improved test coverage and reliability of `newOrder` controller error handling.

---
*PR created automatically by Jules for task [8372143453797153644](https://jules.google.com/task/8372143453797153644) started by @parilsanghvi*