### PR TITLE
🧪 [testing] add missing 400 status check for payment intent error

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -241,6 +241,7 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment not verified');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail if req paymentInfo.status is not succeeded', async () => {
@@ -259,6 +260,7 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment status mismatch');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail on payment amount mismatch (Stripe amount vs calculated amount)', async () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing assertion for the 400 status code returned by the payment validation error branches in `backend/controllers/orderController.js:101`. The tests previously only asserted the error message, but now explicitly verify the expected HTTP status code is applied correctly to the ErrorHandler.

📊 **Coverage:** What scenarios are now tested
This change explicitly verifies the error status code for two payment failure branches during `newOrder` execution:
1. When the Stripe payment intent status is not 'succeeded' ("Payment not verified").
2. When the provided request body payment info status is not 'succeeded' ("Payment status mismatch").

✨ **Result:** The improvement in test coverage
Tests for the `newOrder` controller are now more robust and will fail if a developer accidentally alters the status code returned in these critical payment verification branches, reducing the chance of undetected regressions in client-facing error handling.

---
*PR created automatically by Jules for task [15072916140577210342](https://jules.google.com/task/15072916140577210342) started by @parilsanghvi*