### PR TITLE
🧪 Add test for taxPrice validation when taxPrice is NaN

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -187,6 +187,20 @@ describe('newOrder Controller', () => {
         expect(mockNext.mock.calls[0][0].message).toContain('Tax price mismatch detected. Please refresh and try again.');
     });
 
+    it('should fail when taxPrice is NaN', async () => {
+        const req = {
+            body: getValidReqBody(),
+            user: testUser
+        };
+        req.body.taxPrice = 'invalid_number';
+
+        await orderController.newOrder(req, mockRes, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
+        expect(mockNext.mock.calls[0][0].message).toContain('Tax price mismatch detected. Please refresh and try again.');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
+    });
+
     it('should fail on shippingPrice mismatch', async () => {
         const req = {
             body: getValidReqBody(),


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing validation check for `taxPrice` being an invalid number (NaN) in the `orderController.newOrder` function logic.
📊 **Coverage:** A test case has been added to cover the scenario where `taxPrice` evaluates to `NaN` (e.g., when a string like `"invalid_number"` is provided). It explicitly checks that an `ErrorHandler` is invoked with the status code `400` and the correct validation error message.
✨ **Result:** Test coverage for price tampering and invalid inputs is improved, ensuring the endpoint safely rejects invalid tax price formats before attempting to record them.

---
*PR created automatically by Jules for task [14955018889751471468](https://jules.google.com/task/14955018889751471468) started by @parilsanghvi*