### PR TITLE
🧪 Add status code assertion to newOrder error tests

### DIFF
--- a/backend/tests/orderController_newOrder.test.js
+++ b/backend/tests/orderController_newOrder.test.js
@@ -241,6 +241,7 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment not verified');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail if req paymentInfo.status is not succeeded', async () => {
@@ -259,6 +260,7 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment status mismatch');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail on payment amount mismatch (Stripe amount vs calculated amount)', async () => {
@@ -276,6 +278,7 @@ describe('newOrder Controller', () => {
 
         expect(mockNext).toHaveBeenCalledWith(expect.any(ErrorHandler));
         expect(mockNext.mock.calls[0][0].message).toContain('Payment amount mismatch');
+        expect(mockNext.mock.calls[0][0].statusCode).toBe(400);
     });
 
     it('should fail on replay attack (paymentInfo.id already used)', async () => {


### PR DESCRIPTION
🎯 **What:** Added missing status code 400 assertions for payment verification error branches in `newOrder` controller tests.
📊 **Coverage:** The tests now explicitly verify that both `Payment not verified`, `Payment status mismatch`, and `Payment amount mismatch` errors return a 400 status code as expected.
✨ **Result:** Improved test reliability by ensuring both error messages and HTTP status codes are correct during edge cases.

---
*PR created automatically by Jules for task [18406133492066752424](https://jules.google.com/task/18406133492066752424) started by @parilsanghvi*