### PR TITLE
🎨 Palette: Add loading spinner to submit buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -72,3 +72,7 @@
 ## 2025-06-06 - Form Disabled State Consolidation
 **Learning:** Found that the `UpdateProduct` form had a submit button that was correctly disabled during loading, but the input fields, textarea, and select dropdown were still active. This allowed users to modify form values while a submission was already in progress, potentially leading to race conditions or incorrect data being sent if the submission failed and they resubmitted.
 **Action:** When working on async forms, ensure the `disabled={loading}` state is applied uniformly to ALL interactive form elements (inputs, textareas, selects), not just the submit button.
+
+## 2025-06-06 - Submit Button Loading State Visibility
+**Learning:** Found that disabled submit buttons often just change their text to indicate loading, which might be missed by users or seen as a broken disabled button.
+**Action:** Enhance the `disabled={loading}` state of submit buttons by rendering an inline `CircularProgress` component alongside the loading text to provide a clear and standard visual cue for background processing.

--- a/frontend/src/component/User/UpdatePassword.jsx
+++ b/frontend/src/component/User/UpdatePassword.jsx
@@ -12,6 +12,7 @@ import VpnKeyIcon from "@mui/icons-material/VpnKey"
 import Visibility from "@mui/icons-material/Visibility"
 import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { useNavigate } from "react-router-dom";
+import { CircularProgress } from "@mui/material";
 
 const UpdatePassword = () => {
   const dispatch = useDispatch();
@@ -72,7 +73,6 @@ const UpdatePassword = () => {
                     aria-label="Old Password"
                     required
                     value={oldPassword}
-                    disabled={loading}
                     onChange={(e) => setOldPassword(e.target.value)}
                     disabled={loading}
                   />
@@ -94,7 +94,6 @@ const UpdatePassword = () => {
                     aria-label="New Password"
                     required
                     value={newPassword}
-                    disabled={loading}
                     onChange={(e) => setNewPassword(e.target.value)}
                     disabled={loading}
                   />
@@ -116,7 +115,6 @@ const UpdatePassword = () => {
                     aria-label="Confirm Password"
                     required
                     value={confirmPassword}
-                    disabled={loading}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     disabled={loading}
                   />
@@ -134,8 +132,16 @@ const UpdatePassword = () => {
                   type="submit"
                   className="primary-btn"
                   disabled={loading}
+                  style={{ display: "flex", gap: "8px", alignItems: "center", justifyContent: "center" }}
                 >
-                  {loading ? "Changing..." : "Change"}
+                  {loading ? (
+                    <Fragment>
+                      <CircularProgress size={20} color="inherit" />
+                      Changing...
+                    </Fragment>
+                  ) : (
+                    "Change"
+                  )}
                 </button>
               </form>
             </div>

--- a/frontend/src/component/User/UpdateProfile.jsx
+++ b/frontend/src/component/User/UpdateProfile.jsx
@@ -9,6 +9,7 @@ import { useSnackbar } from "notistack";
 import { updateProfileReset } from "../../features/userSlice"; // using exported reset action
 import MetaData from "../layout/MetaData";
 import { useNavigate } from "react-router-dom";
+import { CircularProgress } from "@mui/material";
 
 const UpdateProfile = () => {
   const dispatch = useDispatch();
@@ -122,8 +123,16 @@ const UpdateProfile = () => {
                   type="submit"
                   className="primary-btn"
                   disabled={loading}
+                  style={{ display: "flex", gap: "8px", alignItems: "center", justifyContent: "center" }}
                 >
-                  {loading ? "Updating..." : "Update"}
+                  {loading ? (
+                    <Fragment>
+                      <CircularProgress size={20} color="inherit" />
+                      Updating...
+                    </Fragment>
+                  ) : (
+                    "Update"
+                  )}
                 </button>
               </form>
             </div>


### PR DESCRIPTION
💡 **What:** Added an inline `<CircularProgress>` spinner to the submit buttons in `UpdatePassword.jsx` and `UpdateProfile.jsx` when the form is processing (`disabled={loading}`).

🎯 **Why:** Previously, these disabled submit buttons only indicated their loading state by changing their text (e.g., "Change" -> "Changing..."). While functional, this lacks a standard visual cue for background processing, making it less obvious to users that an asynchronous operation is in progress, and could be mistaken for a broken button. The spinner provides clear, standard feedback.

📸 **Before/After:**
*   **Before:** `<button disabled={loading}>Changing...</button>`
*   **After:** `<button disabled={loading}><CircularProgress size={20} /> Changing...</button>`

♿ **Accessibility:** Provides an immediate, standard visual cue (a moving spinner) that reinforces the text change and the disabled state, improving the perceptibility of the system status for sighted users. The button remains properly disabled during the operation.

---
*PR created automatically by Jules for task [4145598573961483205](https://jules.google.com/task/4145598573961483205) started by @parilsanghvi*