### PR TITLE
🎨 Palette: Add loading spinner and aria-busy to Login/Signup buttons

### DIFF
--- a/frontend/src/__tests__/LoginSignup_Loading.test.jsx
+++ b/frontend/src/__tests__/LoginSignup_Loading.test.jsx
@@ -34,6 +34,15 @@ vi.mock('react-router-dom', async () => {
     };
 });
 
+// Mock Material UI CircularProgress
+vi.mock('@mui/material', async () => {
+    const actual = await vi.importActual('@mui/material');
+    return {
+        ...actual,
+        CircularProgress: () => <span data-testid="circular-progress">Loading...</span>,
+    };
+});
+
 describe('LoginSignup Loading State', () => {
     it('shows loading state and disables inputs', () => {
         render(

--- a/frontend/src/component/User/LoginSignup.jsx
+++ b/frontend/src/component/User/LoginSignup.jsx
@@ -7,6 +7,7 @@ import FaceIcon from "@mui/icons-material/Face"
 import Visibility from "@mui/icons-material/Visibility"
 import VisibilityOff from "@mui/icons-material/VisibilityOff"
 import { MdErrorOutline } from "react-icons/md";
+import { CircularProgress } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux"
 import { clearErrors, login, register } from "../../features/userSlice";
 import { useSnackbar } from "notistack"
@@ -202,7 +203,8 @@ const LoginSignup = () => {
                             </button>
                         </div>
                         <Link to="/password/forgot">Forgot Password ?</Link>
-                        <button type="submit" className='primary-btn' disabled={loading}>
+                        <button type="submit" className='primary-btn' disabled={loading} aria-busy={loading} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+                            {loading ? <CircularProgress size={20} color="inherit" /> : null}
                             {loading ? "Logging In..." : "Login"}
                         </button>
                     </form>
@@ -275,7 +277,8 @@ const LoginSignup = () => {
                                 onChange={registerDataChange}
                             />
                         </div>
-                        <button type="submit" className='primary-btn' disabled={loading}>
+                        <button type="submit" className='primary-btn' disabled={loading} aria-busy={loading} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+                            {loading ? <CircularProgress size={20} color="inherit" /> : null}
                             {loading ? "Registering..." : "Register"}
                         </button>
                     </form>


### PR DESCRIPTION
💡 What: Added `<CircularProgress>` from `@mui/material` and `aria-busy={loading}` attribute to the submit buttons on the Login and Signup forms. Also mocked `CircularProgress` in the relevant test.
🎯 Why: Provides immediate visual feedback to the user when the authentication request is processing.
📸 Before/After: N/A (Visual change to add loading spinner inside the button during async operations)
♿ Accessibility: The addition of `aria-busy={loading}` notifies screen readers that the section is currently updating/processing.

---
*PR created automatically by Jules for task [3270279511364616684](https://jules.google.com/task/3270279511364616684) started by @parilsanghvi*