### PR TITLE
🧹 Remove false positive security comments from error middleware

### DIFF
--- a/backend/middleware/error.js
+++ b/backend/middleware/error.js
@@ -3,7 +3,7 @@ module.exports = (err, req, res, next) => {
     err.statusCode = err.statusCode || 500;
     err.message = err.message || "internal server error"
 
-    // Security Fix: Do not leak error details in production for 500 errors
+    // Do not leak error details in production for 500 errors
     if (process.env.NODE_ENV === 'PRODUCTION' || process.env.NODE_ENV === 'production') {
         if (err.statusCode === 500) {
             err.message = 'Internal Server Error';
@@ -36,7 +36,7 @@ module.exports = (err, req, res, next) => {
         err = new ErrorHandler(message, 400);
     }
 
-    // Security Fix: Prevent Information Disclosure in production for 500 errors
+    // Prevent Information Disclosure in production for 500 errors
     let finalMessage = err.message;
     if (err.statusCode === 500 && (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'PRODUCTION')) {
         console.error("Internal Server Error:", err); // Log actual error for debugging


### PR DESCRIPTION
🎯 **What:**
Removed "Security Fix:" trigger words from comments in the error handling middleware (`backend/middleware/error.js`).

💡 **Why:**
The comments accurately described security fixes (preventing error leakage in production) that were *already* implemented. However, the presence of the exact phrase "Security Fix:" was acting as a false positive, likely triggering automated tech debt trackers, security scanners, or linters into falsely believing these were pending tasks.

✅ **Verification:**
- Verified via `read_file` that the comments have been successfully reworded.
- Ran backend test suite (`pnpm run test:backend`) to ensure no baseline regressions were caused by this change.

✨ **Result:**
The code remains functionally identical (secure error handling is preserved), but automated tools will no longer flag this file with a false positive.

---
*PR created automatically by Jules for task [6785832814275993830](https://jules.google.com/task/6785832814275993830) started by @parilsanghvi*