### PR TITLE
🧪 Add error path test for save failure in forgotPassword

### DIFF
--- a/backend/tests/unit/userController_forgotPassword.test.js
+++ b/backend/tests/unit/userController_forgotPassword.test.js
@@ -155,4 +155,31 @@ describe('forgotPassword Controller', () => {
             testError
         );
     });
+
+    it('should log error if saving user fails after email sending failure', async () => {
+        User.findOne.mockResolvedValue(mockUser);
+
+        const testError = new Error('Email failed');
+        sendEmail.mockRejectedValue(testError);
+
+        const saveError = new Error('Save failed');
+        mockUser.save
+            .mockResolvedValueOnce(true)
+            .mockRejectedValueOnce(saveError);
+
+        await userController.forgotPassword(req, res, next);
+
+        for (let i = 0; i < 10; i++) {
+            await Promise.resolve();
+        }
+
+        expect(console.error).toHaveBeenCalledWith(
+            "Failed to send password reset email asynchronously:",
+            testError
+        );
+        expect(console.error).toHaveBeenCalledWith(
+            "Failed to clear reset token after email failure:",
+            saveError
+        );
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap in `forgotPassword` was that the catch block (which handles background email sending failures and resets the token) was partially tested, but the nested fallback save operation failure wasn't covered. 

📊 **Coverage:** A new test case has been added to `backend/tests/unit/userController_forgotPassword.test.js`. The new scenario explicitly mocks `sendEmail` to reject and concurrently forces `user.save` to reject on its second call. This covers lines 116-118 in `backend/controllers/userController.js` (the `saveErr` handler).

✨ **Result:** Test coverage for `userController_forgotPassword` is increased, closing a gap in the nested asynchronous error handlers and ensuring we correctly catch and log infrastructure failures without crashing.

---
*PR created automatically by Jules for task [15626609822909888730](https://jules.google.com/task/15626609822909888730) started by @parilsanghvi*