### PR TITLE
🧹 Clean up false positive security marker in error middleware

### DIFF
--- a/backend/middleware/error.js
+++ b/backend/middleware/error.js
@@ -3,7 +3,7 @@ module.exports = (err, req, res, next) => {
     err.statusCode = err.statusCode || 500;
     err.message = err.message || "internal server error"
 
-    // Security Fix: Do not leak error details in production for 500 errors
+    // Do not leak error details in production for 500 errors
     if (process.env.NODE_ENV === 'PRODUCTION' || process.env.NODE_ENV === 'production') {
         if (err.statusCode === 500) {
             err.message = 'Internal Server Error';
@@ -36,7 +36,7 @@ module.exports = (err, req, res, next) => {
         err = new ErrorHandler(message, 400);
     }
 
-    // Security Fix: Prevent Information Disclosure in production for 500 errors
+    // Prevent Information Disclosure in production for 500 errors
     let finalMessage = err.message;
     if (err.statusCode === 500 && (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'PRODUCTION')) {
         console.error("Internal Server Error:", err); // Log actual error for debugging


### PR DESCRIPTION
🎯 **What:** Removed the "Security Fix:" prefix from the error middleware comments.
💡 **Why:** The security fix to prevent leaking error details in production for 500 errors was already implemented. The remaining "Security Fix:" marker in the comment was triggering automated scanners to falsely flag the resolved issue as an active task.
✅ **Verification:** Verified by code inspection and running the backend test suite.
✨ **Result:** Prevented future false positives in automated security tooling without altering application functionality.

---
*PR created automatically by Jules for task [7698472557887518285](https://jules.google.com/task/7698472557887518285) started by @parilsanghvi*