### PR TITLE
🧪 Add integration test for payment items array length limit

### DIFF
--- a/backend/tests/integration/payment.test.js
+++ b/backend/tests/integration/payment.test.js
@@ -135,6 +135,21 @@ describe('Payment Integration Tests', () => {
             expect(res.body.message).toBe('Stripe Error');
         });
 
+        it('should return 400 if items array length exceeds 100', async () => {
+            const mockItems = Array.from({ length: 101 }, (_, i) => ({
+                product: testProduct._id.toString(),
+                quantity: 1
+            }));
+
+            const res = await request(app)
+                .post('/api/v1/payment/process')
+                .set('Cookie', userCookie)
+                .send({ items: mockItems });
+
+            expect(res.status).toBe(400);
+            expect(res.body.message).toBe('Too many items in payment request');
+        });
+
         it('should return 401 without authentication', async () => {
             const res = await request(app)
                 .post('/api/v1/payment/process')

--- a/backend/tests/unit/userController_registerUser.test.js
+++ b/backend/tests/unit/userController_registerUser.test.js
@@ -6,6 +6,13 @@ const sendToken = require('../../utils/jwtToken');
 
 // Mock dependencies
 jest.mock('../../models/userModel');
+jest.mock('cloudinary', () => ({
+    v2: {
+        uploader: {
+            upload: jest.fn()
+        }
+    }
+}));
 jest.mock('../../utils/jwtToken');
 // Mock catchAsyncErrors
 jest.mock('../../middleware/catchAsyncErrors', () => (func) => (req, res, next) => {


### PR DESCRIPTION
🎯 **What:** 
Added a missing edge case integration test to `payment.test.js`. The test verifies the security fix that limits the `items` array in the `processPayment` request payload to a maximum of 100 items to prevent Denial of Service (DoS) attacks.

📊 **Coverage:** 
- The new test validates that the backend returns a `400 Bad Request` with the message "Too many items in payment request" when the `items` array length exceeds 100.
- Replaced a missing cloudinary mock in `userController_registerUser.test.js` to maintain robust testing without external requests.

✨ **Result:** 
Improved test coverage for the payment controller by guaranteeing that this critical safeguard remains effective and won't be accidentally removed during future refactoring without tests failing.

---
*PR created automatically by Jules for task [15419155716066842246](https://jules.google.com/task/15419155716066842246) started by @parilsanghvi*